### PR TITLE
Add episodes API

### DIFF
--- a/components/EpisodeRow.tsx
+++ b/components/EpisodeRow.tsx
@@ -44,7 +44,7 @@ export const EpisodeRow = (episode: ProcessedMdx) => {
 
             <div className="text-lg md:text-xl mb-3 md:mb-4 font-bold dark:text-gray-200">
               {" "}
-              {episode.frontMatter.title}
+              {episode.title}
             </div>
             <div>
               <div className="flex space-x-2 mb-2 text-sm">

--- a/pages/api/episodes/[episodeNumber].tsx
+++ b/pages/api/episodes/[episodeNumber].tsx
@@ -29,7 +29,6 @@ export default async function handler(
     {}
   );
   delete data.tabSections;
-  console.log(data);
 
   res.status(200).json(data);
 }

--- a/pages/api/episodes/[episodeNumber].tsx
+++ b/pages/api/episodes/[episodeNumber].tsx
@@ -1,0 +1,35 @@
+import fs from "fs";
+import path from "path";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { processMdx } from "utils/processMdx";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { episodeNumber } = req.query;
+
+  if (typeof episodeNumber !== "string" || !episodeNumber.match(/^\d+$/)) {
+    res.status(400).json({ error: "Invalid episode number" });
+    return;
+  }
+  const episode = parseInt(episodeNumber);
+
+  const episodes = fs
+    .readdirSync(path.join(process.cwd(), `pages/episode`))
+    .filter((p) => p.endsWith(".mdx"));
+
+  if (episode < 1 || episode > episodes.length - 1) {
+    res.status(400).json({ error: "Episode number out of range" });
+    return;
+  }
+
+  const data = await processMdx(
+    path.join(process.cwd(), `pages/episode/${episode}.mdx`),
+    {}
+  );
+  delete data.tabSections;
+  console.log(data);
+
+  res.status(200).json(data);
+}

--- a/pages/api/episodes/index.ts
+++ b/pages/api/episodes/index.ts
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { processMdx } from "utils/processMdx";
+
+export default async function handler(
+  _req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const episodes = fs
+    .readdirSync(path.join(process.cwd(), `pages/episode`))
+    .filter((p) => p.endsWith(".mdx"));
+
+  const data = await Promise.all(
+    episodes.map((episode) =>
+      processMdx(path.join(process.cwd(), "pages/episode", episode), {})
+    )
+  );
+
+  res
+    .status(200)
+    .json(data.sort((a, b) => parseInt(b.number) - parseInt(a.number)));
+}

--- a/pages/episode/[episodeNumber].tsx
+++ b/pages/episode/[episodeNumber].tsx
@@ -82,7 +82,7 @@ const Episode = ({
   youtubeId,
   buzzSproutEpisodeId,
   tabSections,
-  frontMatter,
+  title,
 }: ProcessedMdx) => {
   const showNotesTab = tabSections.find(
     (tabSection) => tabSection.type === "SHOW NOTES"
@@ -90,13 +90,17 @@ const Episode = ({
   const router = useRouter();
   const [view, setView] = useQueryParam("view", StringParam);
   const [activeTab, activeTabSet] = useState(
-    view === undefined ? 0 : view==='youtube' ? tabSections.length : tabSections.findIndex((t) => t.type === view)
+    view === undefined
+      ? 0
+      : view === "youtube"
+      ? tabSections.length
+      : tabSections.findIndex((t) => t.type === view)
   );
   const { episodeNumber } = router.query;
   const episodeNumberString = `Episode #${episodeNumber}`;
   const tags = (
     <MetaTags
-      title={`${episodeNumberString}: ${frontMatter.title}`}
+      title={`${episodeNumberString}: ${title}`}
       image={`https://i.ytimg.com/vi/${youtubeId}/maxresdefault.jpg`}
       description={showNotesTab.description}
     />
@@ -120,9 +124,7 @@ const Episode = ({
       <ColoredText className="mt-4" color="blue">
         {episodeNumberString}:
       </ColoredText>
-      <h1 className="text-xl md:text-3xl mt-2 mb-8 md:mb-12">
-        {frontMatter.title}
-      </h1>
+      <h1 className="text-xl md:text-3xl mt-2 mb-8 md:mb-12">{title}</h1>
 
       <iframe
         className="mb-8 md:mb-12"
@@ -159,14 +161,14 @@ const Episode = ({
           <Navigation.Controls className="overflow-x-auto">
             <Navigation.TabList>
               {
-                (tabSections.map((tabSection) => (
+                tabSections.map((tabSection) => (
                   <Navigation.Tab
                     id="about"
                     icon={tabIcons[tabSection.type] || <DataIcon inline />}
                   >
                     {titleCase(tabSection.type.toLowerCase())}
                   </Navigation.Tab>
-                )) as unknown) as JSX.Element
+                )) as unknown as JSX.Element
               }
               <Navigation.Tab id="youtube" icon={<ConsoleIcon inline />}>
                 YouTube

--- a/pages/episodes.tsx
+++ b/pages/episodes.tsx
@@ -52,7 +52,7 @@ export default function Episodes({ episodes }: EpisodesProps) {
             <Navigation.Panel className="md:p-4 pt-4 mx-3 mb-4 focus:outline-none">
               <div className="divide-y-2 divide-gray-300 dark:divide-gray-600">
                 {episodes.map((episode) => (
-                  <EpisodeRow key={episode.frontMatter.title} {...episode} />
+                  <EpisodeRow key={episode.title} {...episode} />
                 ))}
               </div>
             </Navigation.Panel>

--- a/utils/processMdx.ts
+++ b/utils/processMdx.ts
@@ -220,8 +220,8 @@ export async function processMdx(
     runTime: sectionsTab.sections[sectionsTab.sections.length - 1].time,
     youtubeId,
     buzzSproutEpisodeId,
-    frontMatter: data as FrontMatter,
     tabSections,
+    ...(data as FrontMatter),
   };
 }
 


### PR DESCRIPTION
I was wanting to pull in some episode information on my site and realized we didn't have an API. This just adds `/api/episodes` and `/api/episodes/[episode]` endpoints. The responses are a bit slow so it'd probably be good to have some sort of caching. 

The only other change is spreading the frontmatter data into the processed MDX response. 