### PR TITLE
remove Google Podcasts as it is 404

### DIFF
--- a/components/LinkShieldList.tsx
+++ b/components/LinkShieldList.tsx
@@ -23,11 +23,6 @@ export const PODCAST_LINKS: ActionLinkProps[] = [
     text: "Spotify",
   },
   {
-    src: "/platform-logos/google.svg",
-    href: "https://podcasts.google.com/feed/aHR0cHM6Ly9mZWVkcy5idXp6c3Byb3V0LmNvbS8xNzcyOTkyLnJzcw",
-    text: "Google Podcasts",
-  },
-  {
     src: "/brand-assets/favicon.png",
     href: "https://devtools.fm/rss.xml",
     text: "Website RSS Feed",


### PR DESCRIPTION
the current icon/link to Google Podcasts on https://www.devtools.fm/ leads to https://podcasts.google.com/feed/aHR0cHM6Ly9mZWVkcy5idXp6c3Byb3V0LmNvbS8xNzcyOTkyLnJzcw which shows "Google Podcasts is no longer available"

<img width="255" alt="image" src="https://github.com/user-attachments/assets/a618e393-b9ae-4d73-850d-9949d56ffb98" />

<img width="615" alt="image" src="https://github.com/user-attachments/assets/253e94c4-9287-4498-a9a6-854eac5e1a85" />

---

unsure if it would make more sense to replace the logo (for the YouTube Music one) and link to https://music.youtube.com/playlist?list=PLLty5W8WOTPws8lWMoGh-qwNbtah-Q9Qx instead of just removing the Google Podcasts logo..?

cheers!