### PR TITLE
Add sponsor field support to episodes

### DIFF
--- a/components/EpisodeRow.tsx
+++ b/components/EpisodeRow.tsx
@@ -78,6 +78,16 @@ export const EpisodeRow = (episode: ProcessedMdx) => {
                 </ul>
               </div>
             )}
+            {episode.frontMatter.sponsor && (
+              <div className="flex space-x-2 mb-2 text-sm">
+                <ColoredText color="purple">Sponsored by:</ColoredText>
+                <span className="dark:text-gray-300">
+                  {Array.isArray(episode.frontMatter.sponsor) 
+                    ? episode.frontMatter.sponsor.join(', ')
+                    : episode.frontMatter.sponsor}
+                </span>
+              </div>
+            )}
           </div>
         </div>
         <DimmedText>{episode.runTime}</DimmedText>

--- a/pages/episode/100.mdx
+++ b/pages/episode/100.mdx
@@ -3,6 +3,7 @@ title: Solomon Hykes - Docker, Dagger, and the Future of DevOps
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Solomon-Hykes---Docker--Dagger--and-the-Future-of-DevOps-e2k4ujm
 youtube: https://www.youtube.com/watch?v=UVED44sb7zg
 tags: technology, podcast, coding, docker, programming, devops, continuous integration, typescript, go, bash, python
+sponsor: Clerk
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/101.mdx
+++ b/pages/episode/101.mdx
@@ -1,5 +1,6 @@
 ---
 title: Dan Farrelly, Tony Holdstock-Brown - Inngest, Easy Asynchronous Workflows 
+sponsor: Clerk
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Dan-Farrelly--Tony-Holdstock-Brown---Inngest--Easy-Asynchronous-Workflows-e2kdn98
 youtube: https://www.youtube.com/watch?v=iSgrCnk82Jw
 tags: technology, coding, programming, typescript, javascript, async, workflows, inngest, serverless, cloudflare, cloud functions, state management

--- a/pages/episode/101.mdx
+++ b/pages/episode/101.mdx
@@ -1,9 +1,9 @@
 ---
-title: Dan Farrelly, Tony Holdstock-Brown - Inngest, Easy Asynchronous Workflows 
-sponsor: Clerk
+title: Dan Farrelly, Tony Holdstock-Brown - Inngest, Easy Asynchronous Workflows
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Dan-Farrelly--Tony-Holdstock-Brown---Inngest--Easy-Asynchronous-Workflows-e2kdn98
 youtube: https://www.youtube.com/watch?v=iSgrCnk82Jw
 tags: technology, coding, programming, typescript, javascript, async, workflows, inngest, serverless, cloudflare, cloud functions, state management
+sponsor: Clerk
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -62,7 +62,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 Could you tell our audience more about yourselves?
 
-**Dan:** Yeah, sure. Go ahead, Tony. 
+**Dan:** Yeah, sure. Go ahead, Tony.
 
 **Tony:** Cool. Awesome. Yeah. Uh, my name is Tony, one of the founders of inngest. Um, been coding since I was a kid. Learned how to code [00:01:00] by accident.
 
@@ -86,13 +86,13 @@ basically full in on, on, on coding and programming.
 
 And then I was like, Selling things as a business that I started that failed miserably, but it was something else. It was in music. And then, uh, kind of fell into the, to the programming side of things and just loved it. And, you know, met Tony early on in that journey. And then kind of, we made a little round trip, uh, caught up with him several years later and we started this thing together.
 
-But you know, I went on in the meantime to become the CTO at a company called Buffer, which does like social media, uh, scheduling software. And whatnot. So that was really great experience. It kind of teed me up for some of this experience that, uh, that Tony and I have, uh, since, uh, since had together, but That's a little bit about us. 
+But you know, I went on in the meantime to become the CTO at a company called Buffer, which does like social media, uh, scheduling software. And whatnot. So that was really great experience. It kind of teed me up for some of this experience that, uh, that Tony and I have, uh, since, uh, since had together, but That's a little bit about us.
 
-**Justin:** That's cool. We use buffer, so that's fun. 
+**Justin:** That's cool. We use buffer, so that's fun.
 
-**Dan:** Amazing. I hope, I hope, I hope that none of my code is still there at in production, but I'm sure it is. It's one of those things like when you're early enough at a startup, you're like, Oh God. Please, I hope I always told the team to blame all the mistakes on me, all the bugs on me. 
+**Dan:** Amazing. I hope, I hope, I hope that none of my code is still there at in production, but I'm sure it is. It's one of those things like when you're early enough at a startup, you're like, Oh God. Please, I hope I always told the team to blame all the mistakes on me, all the bugs on me.
 
-**Andrew:** So let's, let's jump right into it. 
+**Andrew:** So let's, let's jump right into it.
 
 
 #### [00:02:58] What is Inngest?
@@ -117,7 +117,7 @@ particular steps, wait for this other thing to happen.
 
 For up to 24 hours. And if it doesn't happen,
 
-do X, Y, and Z and the lack of something happening is, it's so hard to do in a system like Kafka. Um, so yeah, it's sort of by necessity because of, uh, because of the challenges building workflows by yourself. 
+do X, Y, and Z and the lack of something happening is, it's so hard to do in a system like Kafka. Um, so yeah, it's sort of by necessity because of, uh, because of the challenges building workflows by yourself.
 
 **Dan:** ~~Yeah. And I guess that like share, Oh, go ahead, Justin.~~
 
@@ -145,7 +145,7 @@ I guess like on top of that, just quickly, it's basically an SDK that you drop i
 
 So pretty simple, pretty easy to get started. You don't really need to learn [00:08:00] much, but it's also really powerful and it doesn't hide any of the complexity of the things that you need to do if you really want to.
 
-**Justin:** That's really cool. 
+**Justin:** That's really cool.
 
 
 #### [00:08:07] Ad
@@ -183,7 +183,7 @@ So we're talking to y'all and I think y'all do a really, really great job. Job o
 
 Can you talk a little bit about like how you thought about. Building this as a company, uh, and why you thought this was the right space and kind of how you think about this, like market movement in
 
-~~general.~~ 
+~~general.~~
 
 **Tony:** yeah, there's, there's a lot to say. Um, there's so much to say and it's a really good point. There's like a few meta things that I think to observe before going into inngest specifically and, [00:12:00] um, the direction that the industry has been heading in, which is super interesting and like one of the things.
 
@@ -265,9 +265,9 @@ Something horizontal. And that's also why inngest is every language. It can go a
 
 If you're building something complex. So, you know, I think that to that discussion, it's just, it's kind of a funny thing, right? It's just funny thing. It's as developers are going to debate, but, uh, you know, I think it comes down to you have different options and it doesn't mean that you can't mix a vertical Thing with a horizontal solution, right?
 
-Uh, everyone always layers, layers things on and the ability to compose what you know, your application in the way that you need for the software that you're building is extremely important. So, you know, that's how we approach that. And I think, you know, you're, 
+Uh, everyone always layers, layers things on and the ability to compose what you know, your application in the way that you need for the software that you're building is extremely important. So, you know, that's how we approach that. And I think, you know, you're,
 
-you know, there's different paths with it. 
+you know, there's different paths with it.
 
 **Tony:** It's also interesting that like last thing you mentioned active job and then the way of working. I think it all makes sense. But like one of the things that we realized in the front end world a while back is just a state sucks. Like state sucks. useState [00:18:00] sucks, producers suck. How do you make all of this work?
 
@@ -275,7 +275,7 @@ And there's the whole signals thing that people are like, Oh, finally reactivity
 
 And if you need to cancel it, you need to add another API handler, load everything, properly cancel, maybe reschedule. And you end up building, you end up building your own system on top of the underlying primitives. That sucks. You shouldn't necessarily have to do that at all. It takes so much time, effort, and it will, it will be buggy, and there's no observability.
 
-That's the hardest thing. I think, like, figuring out what goes wrong in a system like that is extremely challenging. So, I think, uh, it makes sense to start with the infrastructure, and that's what we've been doing for the last 15 years, but it also makes sense to go one step further and solve our problems as developers 
+That's the hardest thing. I think, like, figuring out what goes wrong in a system like that is extremely challenging. So, I think, uh, it makes sense to start with the infrastructure, and that's what we've been doing for the last 15 years, but it also makes sense to go one step further and solve our problems as developers
 
 **Dan:** Yeah, and that's really at the end of the day, just like, I mean, developer experience, like developers demand more, there's more demand on them, you [00:19:00] know, we just need to, that's to the point of this podcast, right? It's like developers love their tools, give them better tools, give them better abstractions, you know, that's, that's what, that's what we need to do.
 
@@ -302,7 +302,7 @@ And I think that's really key because developers can like look at a complex thin
 
 And you know, I think where we approach it from the, that dev server and the SDK example, and that's, I think one of the things that resonates with people when they just get it, they're like, when I get the dev server running, it's just, I understand what's happening, right? Like I can see my code running in the way that like traditionally background logic, like you never see it.
 
-Right. And that's what makes it harder. Especially if you've been on the front end or you've been somewhere else, you just can't visualize something that's long running for days or weeks. But if you can put it in the UI, if you can make it interactive, it's a major unlock for devs. 
+Right. And that's what makes it harder. Especially if you've been on the front end or you've been somewhere else, you just can't visualize something that's long running for days or weeks. But if you can put it in the UI, if you can make it interactive, it's a major unlock for devs.
 
 **Tony:** ~~Yeah.~~ Yeah. There's also a few principles that we really care about. We shouldn't really replace programming [00:23:00] primitives. We shouldn't really do things that are not idiomatic to your language. That sucks. No developer wants to do that. Um, and so making sure that we give you all the power of the systems, but really simply so that you almost only have to learn a few primitives without learning the underlying infrastructure. It's basically the whole goal. Um, so it sounds really cliche. It sounds like business speak, you know, time to value, but genuinely dude, time to value, making sure that it's super easy for people to get set up as quickly as possible is like, is key and, uh, friction sucks across everything that we do in life.
 
@@ -350,7 +350,7 @@ All right. Uh, so they're not like banging their head against the wall every day
 
 So, you know, there's always going to be a push and they're just kind of that wave that you talked about was, is, and is going to continue to evolve over time. And the bar will continue to be pushed, I think. So, you know, does it end? I don't know. You know, we don't know what things look like, but it'll just keep getting, getting kind of like keep ratcheting up and New things will exist, right?
 
-Cause the demand will get higher on all of us. Every engineer. 
+Cause the demand will get higher on all of us. Every engineer.
 
 **Justin:** Another thing that I wanted to ask about is SDK design. Uh, so in a, in a product like yours, like having a good SDK is paramount because this is your product interface. Um, and it's, it's a tricky thing. Uh, I have a startup in a similar [00:31:00] space doing a slightly different thing, but thinking about what the shape of the interface that you expose, what the SDK looks like is, Paramount.
 
@@ -390,7 +390,7 @@ And I think that is a really, really, really big mind shift difference because e
 
 **Andrew:** ~~go ahead.~~
 
-**Dan:** ~~I, you know what I can, I, can I jump in on a point there or so? Yeah.~~~~ ~~I 
+**Dan:** ~~I, you know what I can, I, can I jump in on a point there or so? Yeah.~~~~ ~~I
 
 
 #### [00:33:53] Serverless and Multi-Tenant Environments
@@ -411,23 +411,23 @@ So anywhere that you [00:36:00] can really run it, like, that's the point. So it
 
 We say, keep doing that. Run your inngest functions, wherever they, wherever you want. It doesn't matter. So that's why we also defaulted to like, we invoke things via HTTP and doesn't mean that we'll always invoke via HTTP. We won't, we'll, we'll do it. We'll have other, other methods, but it at least allows you to like have a workload in any cloud.
 
-It doesn't matter and move it wherever you want or run it locally, run it in CI. It doesn't, you know, anything, anything. Anywhere you want to run it is fine. 
+It doesn't matter and move it wherever you want or run it locally, run it in CI. It doesn't, you know, anything, anything. Anywhere you want to run it is fine.
 
 **Tony:** Yeah. That's it. I think like, actually, like all of this is a meta point thinking about the principles of what you do when you build your system. And for us, one of the principles is like optionality and [00:37:00] flexibility and making it easy for people to develop and not have to change things, not have to spin up new infra, not have to deploy.
 
 A new set of services be able to change clouds if they want to at any particular point, maximizing for optionality is, uh, is really, really key. And, um, I think it's really helpful to figure out as a. As a developer overall, um, and we talked about like everyone's talked about that for years, you know code reuse Or making sure that things are customizable.
 
-We're thinking about interfaces and like joe armstrong amazing r. i. p Erlang talked about this in in contracts between different systems Being the most important piece like just thinking about yeah optionality and making sure that things are flexible is really key 
+We're thinking about interfaces and like joe armstrong amazing r. i. p Erlang talked about this in in contracts between different systems Being the most important piece like just thinking about yeah optionality and making sure that things are flexible is really key
 
 **Dan:** We have a, we have a number of folks that are, you know, multi language, right? Which means that, uh, you know, they're polyglot teams, whatever, whatever phrase you want to use there. And they have long running complex processes that might invoke a Python function, right? It might be [00:38:00] TypeScript that is calling a Python function.
 
 So you're, you, we have these teams that can then compose their systems in however they really want. So. It allows people, if that's what they're using to be, you know, have purpose driven, like maybe your your M. L. Team is building with python. That's fine. That's great. You know, they're using certain things that are really great in that, uh, in that ecosystem.
 
-So why not just keep that there right of python inngest function and call it from your javascript code. It'll all just kind of work together. Like you don't need to kind of think about how those two are interacting. And I think that's just kind of interesting also, cause, uh, you know, it just kind of dives into what, what, what Tony just kind of, uh, kind of talks about as well. 
+So why not just keep that there right of python inngest function and call it from your javascript code. It'll all just kind of work together. Like you don't need to kind of think about how those two are interacting. And I think that's just kind of interesting also, cause, uh, you know, it just kind of dives into what, what, what Tony just kind of, uh, kind of talks about as well.
 
 **Andrew:** Yeah, it's, it seems like writing your code in, in this paradigm really changes how you think about writing your backend code. Like, or like, as Tony was saying, we like to write things procedurally, but it seems like if you like took this to his logical conclusion in your code base, you'd be writing lots of [00:39:00] like really modular functions that you like intersperse.
 
-Yeah. So like, uh, what, what patterns do you think the framework stresses? And then also when I was reading through the docs, you guys had a lot on end impotency, uh, like how does that all play into this too? 
+Yeah. So like, uh, what, what patterns do you think the framework stresses? And then also when I was reading through the docs, you guys had a lot on end impotency, uh, like how does that all play into this too?
 
 **Tony:** maybe I
 
@@ -445,18 +445,18 @@ Um, a couple of other users were sending, you know, tens of thousands of things,
 
 Um, and you're, and you're good to go. Um, there are some patterns for sure that you get introduced to along the way, um, as you get more advanced. So fan out where one of them can do 10 different things in parallel. Or where one parent function can invoke many child functions, um, or do event coordination to say, I want to check for the presence or absence of these 10 events in the future, totally possible or relatively easy, um, because it's just a line of code, um, getting started should be simple.
 
-I think, um, the tough thing about building developer tools that's relatively abstract is, uh, you can never predict what developers are trying to build. And so trying to make something that handles every case is, is hard. Um, so it comes back to the primitives that's available really. 
+I think, um, the tough thing about building developer tools that's relatively abstract is, uh, you can never predict what developers are trying to build. And so trying to make something that handles every case is, is hard. Um, so it comes back to the primitives that's available really.
 
 
 #### [00:41:56] Handling Idempotency in Distributed Systems
 
 **Tony:** Um, I don't Potancy though.
 
-Don't know. So it's, it's a 
+Don't know. So it's, it's a
 
-fun 
+fun
 
-one. 
+one.
 
 **Dan:** Yeah. [00:42:00] Yeah. And you know what, this is a difficult one. So we have a couple ways that you can handle and just to take a step back, uh, item potency. Right? Uh, and however, everyone pronounce it a little differently. You know, devs when they learn it, whatever. Uh, but basically it means like I can run this code as many times as I want, and it will have the same effect, right?
 
@@ -478,7 +478,7 @@ Resume it at the point that you stopped your code from executing. So with that, 
 
 And that's, I think [00:46:00] what's hard is, is like when you're designing the SDK, it's How do you anticipate the flexibility that someone can write and combine maybe two things together or compose some sort of compound key. So you need to be able to be flexible. So, um, yeah, it's a, it's a, it's a tricky problem and no one really likes like handling it.
 
-So I don't, but, but it's a bear. It's always going to be there. 
+So I don't, but, but it's a bear. It's always going to be there.
 
 **Tony:** Distributed systems are fun, T O D L. Yeah,
 
@@ -486,11 +486,11 @@ So I don't, but, but it's a bear. It's always going to be there.
 
 It's got a bunch of YAML that are defining these jobs, which, you know, thank [00:47:00] God y'all aren't doing that. Uh, uh, a. I think that I could see that could be tricky, uh, for your approach is that say you have a polyglot team and they're defining a bunch of inngest functions that do things on events. It may be easy for them to lose sight of what will actually happen on an event as more and more of this code gets spread throughout different projects in their code base.
 
-So it's like, Oh, order created event comes in and now a bunch of things are happening. And I don't really know everything that's happening from that. So how do you. Provide users visibility with, you know, what would happen or do you? And, um, yeah. Is there any way that they, they know like what they can call or like what they, you know, what events they can invoke or 
+So it's like, Oh, order created event comes in and now a bunch of things are happening. And I don't really know everything that's happening from that. So how do you. Provide users visibility with, you know, what would happen or do you? And, um, yeah. Is there any way that they, they know like what they can call or like what they, you know, what events they can invoke or
 
 like, you know,
 
-kind of that flow. 
+kind of that flow.
 
 **Tony:** yeah, this is an interesting one, definitely. I think like fundamentally, yes, once you, once you look at events and you sort of build an architecture map, it's totally possible to do that. It really depends [00:48:00] on where you are. In the dev server, you register individual apps and those apps run based off of, uh, based off of events. Some people might have a huge system and they might have Java, Python, TypeScript all running together, and it's unlikely that people will bring up all services when they're working on one individual component. In the cloud, it is certainly possible to say, hey, this event triggers these 20 functions. And this is what you should expect to happen based off of these things happening.
 
@@ -502,7 +502,7 @@ Um, so it, it, it's kind of easier to describe the system in this way. It turns 
 
 I think one interesting aspect of like a multi language polyglot company continues to be types. And this is a almost heated debate amongst everyone and, uh, Thrift is no longer [00:50:00] in the conversation. Yay. Um, but, uh, types, whether it's protobuf, whether it's JSON schema or OpenAPI, whether it's, you know, any of the other things that have been going on. Type safety across multiple different languages is kind of insane and, you know, the PIP for types, super cool. Um, but at the same time, making sure that you, uh, that you do things in a type safe way is, is super important. I think that's, that's probably the, the, the thing that, that, that we end up caring about most, um, in the future because the, the system maps.
 
-Yep. Cool. Totally possible to put these architecture diagrams, but, uh, doing things in a safe way, especially. Yeah. Across versioning of events, um, is really interesting because unfortunately, when you build something great in two months time, the requirements going to change, you end up changing the event payload. That means that things inevitably break, or you need to handle versioning across disparate systems yourself, making sure that that is good before you go to production and that you run CI [00:51:00] and it can fail if any of the events are unexpected is extremely important. Um, and that's a huge challenge, um, in. In, in many systems, um, that, that we, that we 
+Yep. Cool. Totally possible to put these architecture diagrams, but, uh, doing things in a safe way, especially. Yeah. Across versioning of events, um, is really interesting because unfortunately, when you build something great in two months time, the requirements going to change, you end up changing the event payload. That means that things inevitably break, or you need to handle versioning across disparate systems yourself, making sure that that is good before you go to production and that you run CI [00:51:00] and it can fail if any of the events are unexpected is extremely important. Um, and that's a huge challenge, um, in. In, in many systems, um, that, that we, that we
 
 definitely want to solve.
 
@@ -586,12 +586,12 @@ We don't care if you're using SemVer or some date string, doesn't matter, but yo
 
 **Tony:** ~~so good ~~
 
-**Andrew:** ~~Cool. So, uh, we'll move on to the next question. I think I'll find an edit in there somehow. Um,~~ 
+**Andrew:** ~~Cool. So, uh, we'll move on to the next question. I think I'll find an edit in there somehow. Um,~~
 
 
 #### [00:52:04] Future Directions and Innovations
 
-**Andrew:** so, uh, before we wrap up the podcast, we like to talk about the future a little bit. So what are you guys working on it in Jess? What's next? What do you want to ship? about it, 
+**Andrew:** so, uh, before we wrap up the podcast, we like to talk about the future a little bit. So what are you guys working on it in Jess? What's next? What do you want to ship? about it,
 
 **Tony:** ~~Okay. ~~Oh, yeah, I can talk about it for sure. There's there's a ton. There's a ton. Um Fundamentally again, it all comes back to the principles of making developers lives easier. Mm hmm And a lot of the stuff that we want to work on, as cool as the technology is, and it's fun and fascinating, doesn't matter if it's not making developers lives better.
 
@@ -605,25 +605,25 @@ Function will stop, event comes in, as soon as it's over 500, the function resum
 
 Um Fantastic and cannot wait because uh, making sure the developers can see what's going on and easily debug super important No one wants a platform to sort of hold them back, especially When they're trying to debug things that's like a high stress environment, you know, and so making that look nicer feel nicer um is going to be so good.
 
-There's some stuff in the background, which we can talk about distributed systems things, but it's more for us and less for our developers. No one will know that we're putting it in place. And 
+There's some stuff in the background, which we can talk about distributed systems things, but it's more for us and less for our developers. No one will know that we're putting it in place. And
 
 so, uh, Yeah, I don't know if we want to go into it, but it's really cool.
 
 **Dan:** Yeah, there's a whole underlying like beast behind the system where it's like we run it multi tenant, right? So there's there's like a lot of fun things that we get to learn underneath About the system to make all these things that work, right? so the actual queuing infrastructure underneath that allows you to run them like multi tenant queuing or just [00:55:00] We handle throttling at our level, right?
 
-Rather than you handling it at the worker level, that stuff will just get better, faster, more, you know, kind of more scaling. And, uh, that I think is the fun part of what we're, uh, what we get to do internally in our team. Uh, cause we get to handle the biggest distribution, 
+Rather than you handling it at the worker level, that stuff will just get better, faster, more, you know, kind of more scaling. And, uh, that I think is the fun part of what we're, uh, what we get to do internally in our team. Uh, cause we get to handle the biggest distribution,
 
 which is great.
 
 **Andrew:** do you guys use inngest to build inngest?
 
-**Dan:** A hundred percent. 
+**Dan:** A hundred percent.
 
 **Tony:** partially. Yes. Yeah. There's a, there's a, there's, there's, there's a lot of our stuff that actually runs like retries, um, sort of replace, um, a bunch of stuff for cancellation, which is just straight up and just functions. Um, A lot of the stuff that you do in the API turns out are just functions. Um, but unfortunately you can't use the queue to build the queue because we needed to build the underlying queuing system.
 
-So we have to build the queuing system regardless. 
+So we have to build the queuing system regardless.
 
-And we'll do that for you. 
+And we'll do that for you.
 
 **Dan:** We, uh, there's, there's a lot of fun. We encourage everyone to dog food, the product right at the company. So engineers pick out things we write. Uh, all sorts of functions that [00:56:00] we can do things like, you know, we shifted off. Like, we don't use intercom. We use inngest and we use, we use recent as our email center.
 
@@ -645,9 +645,9 @@ So it's, it's, it's completely important. So, you know, we always want to find n
 
 And kind of we're here high class DX, really, really high bar for quality and software. We're expecting more, we're expecting to ship more complex features. Where do you think the like next phases of the industry will be like, what are going to be the next important things? And how do you see [00:58:00] yourself playing into that?
 
-If you do it 
+If you do it
 
-all? 
+all?
 
 **Tony:** Such a good question. Wow. Um, from a developer point of view, I think it's particularly industry, I think it's particularly interesting how abstractions built and in a way commoditize the underlying things beneath it. So, AWS commoditized infrastructure, very cool, awesome. Also databases, RDS is cool, you know, NEON is cool, PlanetScale is cool, all of these things are amazing.
 
@@ -661,9 +661,9 @@ And if you can abstract everything to a few lines of code, what does that mean f
 
 Um, and that is awesome across all fronts, back end front end, you know, the signal stuff that we talked about. Amazing. Um, from an engineering point of view, so much is changing as well, fundamentally in terms of like, you know, computational stuff, low level libraries, like the things that people are doing with research right now in terms of how.
 
-To make numbers faster or differentiation faster and uh in ai ml workloads is wild So like there's so many different directions. It's kind of crazy. Um, super cool. Everything is 
+To make numbers faster or differentiation faster and uh in ai ml workloads is wild So like there's so many different directions. It's kind of crazy. Um, super cool. Everything is
 
-fascinating. You learn it all. It's like pokemon 
+fascinating. You learn it all. It's like pokemon
 
 **Dan:** yeah, I think I'll, I'll add one, one thing there is like, you know, we've seen, I think there's different people approaching it in different ways, but I don't think the developers want to fight with infrastructure, right? And I think there's people clapping back against serverless. That was, we have not seen the final definition [01:01:00] of this, right?
 
@@ -677,15 +677,15 @@ And, uh, you know, LLMs are cool and stuff, but they're based on language, which
 
 So there's a, there's a lot of interesting things that will, that will change, I think, with how we build software in the next decade. And, uh, but those problems will be like, those problems will shift, right? It won't be in the infrastructure level at some point, right? It'll be it just keeps moving up. So I think that in the future will be approaching [01:03:00] problems in different ways.
 
-Of course, as we, as we did, you know, we can look back 10 years 
+Of course, as we, as we did, you know, we can look back 10 years
 
-ago and make that 
+ago and make that
 
-same statement. 
+same statement.
 
 **Andrew:** I'm saying it right now. UML will finally have its day. ~~going to. ~~
 
-**Tony:** Do you ever see did you ever see any of the brett victor videos like back in the day like worry is he Worry 
+**Tony:** Do you ever see did you ever see any of the brett victor videos like back in the day like worry is he Worry
 
 dream. Is that his website?
 
@@ -693,28 +693,28 @@ Yeah, and he's got like, the small talk is like a thing and like a great thing f
 
 Dude, all of that stuff is so cool, but I don't know the direction in which we're going in is, uh, It's just like straight up procedural code just as is and low code no code or so hard to so hard to get right As developers, you know, I think we're so entrenched in the way that we work that it's going to be hard to change But that stuff is super cool.
 
-Like he's done so much research 
+Like he's done so much research
 
-huge fan. Yeah. What a 
+huge fan. Yeah. What a
 
 man
 
-**Andrew:** Well, that wraps it up for our questions on this episode. Thanks [01:04:00] for coming on guys. This was a really fun talk into a whole land of cues that I didn't know it existed. Uh, and it looks like you guys have found a really cool solution to that. So thanks for coming on. 
+**Andrew:** Well, that wraps it up for our questions on this episode. Thanks [01:04:00] for coming on guys. This was a really fun talk into a whole land of cues that I didn't know it existed. Uh, and it looks like you guys have found a really cool solution to that. So thanks for coming on.
 
-**Tony:** awesome No, thank 
+**Tony:** awesome No, thank
 
-you for having us. Um huge fans again of all you both do so. 
+you for having us. Um huge fans again of all you both do so.
 
 Thank you.
 
-**Dan:** Yeah, thanks, Justin. Thanks, Andrew. 
+**Dan:** Yeah, thanks, Justin. Thanks, Andrew.
 
 **Justin:** Yeah. Tony Dan, complete pleasure. Y'all are, y'all are really pushing forward like a lot of DX in this space. And it's, it's great to see not only because like it's needed, this is like kind of an unfortunate area that's like nice to have a good experience around, but also because it's like, we just need to continue to push the DX envelope forward across the industry.
 
-So I love to see y'all as I like shining example and appreciate the work you're doing. 
+So I love to see y'all as I like shining example and appreciate the work you're doing.
 
 **Dan:** thank you..
 
-**Tony:** Thank you so 
+**Tony:** Thank you so
 
-much 
+much

--- a/pages/episode/102.mdx
+++ b/pages/episode/102.mdx
@@ -1,5 +1,6 @@
 ---
 title: Jason Liu - Instructor, Shipping LLMs to Production
+sponsor: Clerk
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Jason-Liu---Instructor--Shipping-LLMs-to-Production-e2km96b
 youtube: https://www.youtube.com/watch?v=VjJNn5wYZEg
 tags: technology, coding, programming, typescript, llm, ai, prompt engineering, workflows, instructor

--- a/pages/episode/102.mdx
+++ b/pages/episode/102.mdx
@@ -1,9 +1,9 @@
 ---
 title: Jason Liu - Instructor, Shipping LLMs to Production
-sponsor: Clerk
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Jason-Liu---Instructor--Shipping-LLMs-to-Production-e2km96b
 youtube: https://www.youtube.com/watch?v=VjJNn5wYZEg
 tags: technology, coding, programming, typescript, llm, ai, prompt engineering, workflows, instructor
+sponsor: Clerk
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -64,7 +64,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 #### [00:00:00] Introduction
 
-**Jason:** [00:00:00] A good AI product is a product someone will actually think about and use on a regular basis. And I think a great AI product is one where I'm almost a little bit anxious when it's not around anymore, right? I don't really want systems that will try to do my job or do it better than me because I don't believe that can happen. 
+**Jason:** [00:00:00] A good AI product is a product someone will actually think about and use on a regular basis. And I think a great AI product is one where I'm almost a little bit anxious when it's not around anymore, right? I don't really want systems that will try to do my job or do it better than me because I don't believe that can happen.
 
 **Andrew:** Hello, welcome to the DevTools FM podcast. This is a podcast about developer tools and the people who make them. I'm Andrew. And this is my co host, Justin.
 
@@ -86,7 +86,7 @@ And it was like templates. Like you write these like [00:02:00] text templates t
 
 And I was like, Hey, look, it works now. Let me go figure out how, how we can, uh, get some value out of this.
 
-**Andrew:** Cool. 
+**Andrew:** Cool.
 
 
 #### [00:02:47] The Role of an AI Engineer
@@ -99,7 +99,7 @@ I think, you know, a great AI engineer is actually more capable of like doing mo
 
 Right. But if you think about the general task of prompt engineering, it's You know, compared to something like data science, it has always been this translation mode, right? And data science, I'm figuring out how do we take a business problem and turning it into some kind of like metrics and evaluations.
 
-In engineering, we take that same business metrics that we care about and then turn them into prompts. And so I think for the most part, [00:04:00] you know, it's very similar to maybe what data science looks like, you know, in like 2015, 2016. 
+In engineering, we take that same business metrics that we care about and then turn them into prompts. And so I think for the most part, [00:04:00] you know, it's very similar to maybe what data science looks like, you know, in like 2015, 2016.
 
 **Justin:** I've heard some like back and forth on the term prompt engineering online. Some people were like, Hey, yeah, this is like a real field of discipline. Like it's not actually as easy as you might think it may be. And like, it takes a lot of work. And then I've heard it, people be like very dismissive. This is like, reminds me of like, is CSS a programming language or not?
 
@@ -151,7 +151,7 @@ But in these production settings, it's really just, you know, I think between li
 
 With so many different ways to implement auth, like multi factor authentication, SSO, You might even need to implement one of those harder to do enterprise logins if you have an enterprise based business. Or maybe you want to have a bunch of social logins. Setting those up takes time and can be [00:11:00] complicated.
 
-Clerk handles all of that for you without any hassle. 
+Clerk handles all of that for you without any hassle.
 
 One cool thing I learned about Clerk this week is their, Never pay for a user's first day program. It might sound a little confusing at first, but let me explain. So, say you just launched an app, it went on Hacker News, and then blew up to the moon.
 
@@ -252,7 +252,7 @@ And now we have like, obviously AI is a huge hype cycle and we see a lot of comp
 
 And you sort of referenced this a few times. So how do you sort through like valuable usages versus like marketing speak in the.
 
-**Jason:** Yeah, I think the biggest thing is. 
+**Jason:** Yeah, I think the biggest thing is.
 
 
 #### [00:24:18] Building Valuable AI Products
@@ -277,7 +277,7 @@ Like, and then, you know, obviously there's, there are some [00:27:00] that are 
 
 Um, but I think we still have a lot to learn as an industry, uh, for
 
-sure. 
+sure.
 
 
 
@@ -289,7 +289,7 @@ I think it's the same thing in the AI world where we should be pre pricing on th
 
 **Andrew:** Yeah. I like the way you put it of like the anxiety. Like if I think to all of the tools that I like to use that, like. Have AI involved. Like if you took them away from me, yes, I'd be very anxious because like they provide a lot of value to me.
 
-**Jason:** Yeah, like now when I code, I will actually like type something and then pause and then wait for the next completion to happen. And if the completion is slow, I got like, was I unclear? What did I do wrong? Right? Um, and I think you can just, you can tell when that is the case. 
+**Jason:** Yeah, like now when I code, I will actually like type something and then pause and then wait for the next completion to happen. And if the completion is slow, I got like, was I unclear? What did I do wrong? Right? Um, and I think you can just, you can tell when that is the case.
 
 **Andrew:** Yeah. I definitely have that same thing where it's like, Oh no, they're not showing up. I like feel the dread of having to type so much more.
 
@@ -375,7 +375,7 @@ Right. And I think like the consumer base hasn't really grasped that fact yet as
 
 **Justin:** ~~So Andrew, uh, do you want to finish out the questions for this section or should we, should we transition over?~~
 
-**Andrew:** ~~Let's do that last one really quickly. I'm sure he has interesting things to say about it. Uh,~~ 
+**Andrew:** ~~Let's do that last one really quickly. I'm sure he has interesting things to say about it. Uh,~~
 
 
 #### [00:38:59] Cool LLM Projects and Tools
@@ -390,19 +390,19 @@ I have, for example, um, my own libraries documentation in cursor. So when I ask
 
 **Justin:** Yeah, that's, that's really interesting. I think that like, um, It, it is interesting in the way that we're developing new habits around these like tools. Uh, I read a thing about like, uh, the millennial Paul's it's like this reaction where when you're starting to, when like millennials are starting to record themselves, they like pause for a few seconds before the recording starts.
 
-Whereas like Gen Z just like goes straight into it or something. So it's like, I wonder what. What are LLMs going to do to us in this way? [00:41:00] Right. 
+Whereas like Gen Z just like goes straight into it or something. So it's like, I wonder what. What are LLMs going to do to us in this way? [00:41:00] Right.
 
-What ticks are we going to develop? 
+What ticks are we going to develop?
 
 **Jason:** I mean, with the code, with coding now, I basically have that pause. Like, when I go on my friend's computer and I type something, I'll like start the name and I kind of already know what the autocomplete would have given me, but I'm on a different computer and I just look like I'm extra slow. Even the way that I write now, like a lot of my coding is actually using speech to text.
 
-~~Thanks. ~~So I both use speech to text and cursor at the same time. And I'm kind of just very comfortable now with like selecting code, talking a little bit, selecting code, talking a little bit. And, uh, now I definitely can't do that in Vim or on my friend's computer. If I ever had to 
+~~Thanks. ~~So I both use speech to text and cursor at the same time. And I'm kind of just very comfortable now with like selecting code, talking a little bit, selecting code, talking a little bit. And, uh, now I definitely can't do that in Vim or on my friend's computer. If I ever had to
 
-like show them something. 
+like show them something.
 
 **Andrew:** Yes, dictation and LLMs go together very well, because it's like, sometimes when you're writing these prompts, you're like, I just, I, I could just code this in less characters. It might take me less keystrokes to do it in the end. But actually talking to my editor seems like a really nice workflow.
 
-**Jason:** It's been, uh, yeah, I've been using it for a year now. It's pretty good. 
+**Jason:** It's been, uh, yeah, I've been using it for a year now. It's pretty good.
 
 **Justin:** I, um, so we have like iPad babies, you know, who just like [00:42:00] come up like with touchscreens now I'm wondering what, like, what are LLM babies going to be like, they just like want to talk to every computer.
 
@@ -410,7 +410,7 @@ like show them something.
 
 But, for this piece, you know, just do it as quickly as possible. And then you have to reason about whether, like, you want to use Opus or 4. 0. I think there is a bit of a skill and delegation that people are developing because of language models.
 
-**Justin:** Yeah, that's, that's really fun to think about. Um, so let's transition [00:43:00] over and talk about some of the work that you've done. 
+**Justin:** Yeah, that's, that's really fun to think about. Um, so let's transition [00:43:00] over and talk about some of the work that you've done.
 
 
 #### [00:43:02] Instructor
@@ -441,7 +441,7 @@ Because you just might put LLMs in that loop again.
 
 **Justin:** That's really cool. I mean, I think this is like, uh, this kind of tooling is like more of what we need for the [00:46:00] correctness, right? Just like having more confidence that it is doing the things that we want it to do. And especially because if you're feeding it back into some other process in some other system, then it like You know, you want to make sure that that is at least correct. So that's cool.
 
-**Jason:** Yeah, like in the, in the, like, linear case, for example, it, it might make sense to say, okay, given that, given this call transcript, give me the action items as this, like, big markdown file. But that might not be, like, consistently useful. Whereas, if you could generate just the task list that matches the schema of the API call you want to make to linear, and then also assign all these dependencies, Now you can have the structure that is not just a, a linear ticket, but it could be an entire project based on that call. Right? And because you're working with the data structures and because you have this type safety, you know, the code you write ends up being much nicer. Right? If you just ask for JSON, you still have to like parse it and then hope every attribute is correct. And, you know, you still have to make sure that if one ID depends on another ID, that it's assigned correctly, [00:47:00] but the validation kind of captures all of that for you. 
+**Jason:** Yeah, like in the, in the, like, linear case, for example, it, it might make sense to say, okay, given that, given this call transcript, give me the action items as this, like, big markdown file. But that might not be, like, consistently useful. Whereas, if you could generate just the task list that matches the schema of the API call you want to make to linear, and then also assign all these dependencies, Now you can have the structure that is not just a, a linear ticket, but it could be an entire project based on that call. Right? And because you're working with the data structures and because you have this type safety, you know, the code you write ends up being much nicer. Right? If you just ask for JSON, you still have to like parse it and then hope every attribute is correct. And, you know, you still have to make sure that if one ID depends on another ID, that it's assigned correctly, [00:47:00] but the validation kind of captures all of that for you.
 
 **Andrew:** So does it just work on like the output end or like the input end also? So if I'm asking something and I like, does it like, kind of load into context? Like, it should kind of look like this. And then when it gets it out, it validates that it kind of looks like that.
 
@@ -503,22 +503,22 @@ You're just kind of seeing the structure that it produces instead, which I think
 
 So like going up an abstraction layer, let's just have like a solid base that we know is like good, but yeah, more, more support for more frameworks would be interesting.
 
-**Andrew:** Yeah. 
+**Andrew:** Yeah.
 
-**Jason:** You just got to go reach out to Vercel and their white glove service, and you'll have practice to implement the descript. Design, design a framework. 
+**Jason:** You just got to go reach out to Vercel and their white glove service, and you'll have practice to implement the descript. Design, design a framework.
 
-**Andrew:** Yeah, at a low, low price of probably way too much money. Okay. Next up we have LLM 
+**Andrew:** Yeah, at a low, low price of probably way too much money. Okay. Next up we have LLM
 
 
 #### [00:53:49] Tool Tips: LLM Client and Cursor
 
-**Andrew:** client. 
+**Andrew:** client.
 
 **Justin:** yeah, so this is a fun one that I found recently. It's a TypeScript library. Um, well. Come back to that in a second. Uh, but it, it like [00:54:00] implements, uh, a lot of different things. So it's got like rag. It's got react, not, not react to UI again, react to the AI picture, chain of thought, function calling. It works over like different providers.
 
 It's got like a relatively. Uh, like simple AI, uh, and it also has like, uh, open telemetry integration if you want to like do tracing for it. So Andrew, if you scroll down, you can kind of see it'll like give some interesting things. So there was something that I didn't know. It's like part of how this is structured is a, um, There's like some research out of Stanford or something about this, like pretty simple syntax of like describing, uh, like questions and responses and types, like very curiously in a prompt.
 
-It reminds me, Andrew, a little bit of Sudoling we talked about a 
+It reminds me, Andrew, a little bit of Sudoling we talked about a
 
 while back.~~ Yeah.~~ So it got some of that feel to it. Anyway, it does, it does a lot of stuff. Um, and it's kind of interesting. I was like, I'm using it right now to experiment on building a CLI [00:55:00] agent, just to be able to like describe, Hey, I want you to take action, do these things.
 
@@ -526,7 +526,7 @@ Tell me when this file was created and have it like, give me a list of CLI comma
 
 Um, there's some weird build stuff under the hood here. So that's, that's the only, uh, caveat for that, but it's, it's been pretty cool.
 
-**Andrew:** Cool. Next up we have, uh, the combination of cursor, which they got a, a nice new, pretty website. I haven't seen this one yet. Uh, and better dictation. 
+**Andrew:** Cool. Next up we have, uh, the combination of cursor, which they got a, a nice new, pretty website. I haven't seen this one yet. Uh, and better dictation.
 
 **Jason:** Yeah. So like I, uh, I'm, if anyone follows me on Twitter, they kind of know that I've been sort of fighting this like hand injury for the past, like two and a half years. So it's one of the reasons I don't code as much as I used to. And, uh, two of the tools I really use in combination a lot is better dictation that basically uses a on [00:56:00] device language, uh, language model.
 
@@ -534,29 +534,29 @@ So you basically use this like on device, fast English whisper. To, uh, do dicta
 
 Anyways, this is like a, a tool that like my friend had built for me. And then we ended up. You know, building it out. And so if anyone wants to try it out, you can use JSON 20 to get it for 20 bucks. And, uh, yeah, all it does is it just loads, uh, the Hugging Face model locally on your computer. And, uh, yeah, you get access for it for life.
 
-And so if you use this with, uh, Olamo, you can actually code on a plane. And that is a, that is a crazy feeling that, uh, blew my mind at one time when I 
+And so if you use this with, uh, Olamo, you can actually code on a plane. And that is a, that is a crazy feeling that, uh, blew my mind at one time when I
 
-tried it out. 
+tried it out.
 
 **Justin:** ~~Well, yeah.~~
 
 **Andrew:** Yeah. I've been trying to use, like, I kind of got inspired by, uh, Another coder. Who's the guy? Justin, we interviewed him. Scott, Scott Hanselman. [00:57:00] Uh, Scott Hanselman is also very much in the like dictate to code. And then I got home and tried to start dictating with max dictation. Oh my God. How have they not made it better yet?
 
-It's crazy. 
+It's crazy.
 
-**Jason:** I was using the Magitation for about a year and a half, and it completely changed the way that I spoke. Because I would have to enunciate every single word. Uh, in order for it to do well, but, uh, Whisper, obviously it's, it's a lot faster, but it has its own, uh, funny behavior. 
+**Jason:** I was using the Magitation for about a year and a half, and it completely changed the way that I spoke. Because I would have to enunciate every single word. Uh, in order for it to do well, but, uh, Whisper, obviously it's, it's a lot faster, but it has its own, uh, funny behavior.
 
 **Justin:** I don't mean this to be my tool tip, but there's this other project that I've had my eye on, which should be easy to remember. It's called Cursorless. So it's cursorless. org. And it's specifically for coding with your voice. Uh, so yeah, they, they do a lot of really interesting stuff. Uh, around like providing like little visual indicators directly in your IDE to, to like help you jump to different points.
 
 So if you like need to move your cursor around, um, it's a, it's a really [00:58:00] fascinating project. When I was at recurse center, I was doing a little bit of research on, uh, or just like doing a thought experiment is like, what, what would happen if you tried to build a, um, Language for someone who is blind, like just, just build a language for someone who's blind.
 
-And that's like a hard thought experiment. And then like I came to a conference and I actually saw cursor lists. And I mean, obviously you have to be sighted to be able to use this, but, um, for, for people with like hand injuries and stuff, I was like, I think this is, this is pretty interesting. 
+And that's like a hard thought experiment. And then like I came to a conference and I actually saw cursor lists. And I mean, obviously you have to be sighted to be able to use this, but, um, for, for people with like hand injuries and stuff, I was like, I think this is, this is pretty interesting.
 
 **Jason:** Yeah. Like at some point the company I worked for almost suggested I get a typist so I could keep coding. And I realized that it was coding of not just, yeah, coding of not just like editing a single file. Like the thing that ended up driving me crazy. Was, uh, like transitioning through large code bases, right?
 
 Like if, if there was an on call, like it's not one file that has like one typo, it's like, okay, okay. Like look at the error message. Can you online 172, can you jump to that [00:59:00] file? Okay. Can you just double, okay. What's that function name called? Okay. And then can you go back to the original? It gets crazy.
 
-Right. And so that's why I think cursor has like the magic of all the prompts inside. And so. It's able to do that. But this is very cool. I'm definitely going to check it out. Cursorless. 
+Right. And so that's why I think cursor has like the magic of all the prompts inside. And so. It's able to do that. But this is very cool. I'm definitely going to check it out. Cursorless.
 
 **Andrew:** ~~Oh, I don't have the good link. ~~
 
@@ -578,13 +578,13 @@ A bunch of like, matrixy looking ones. There's one where this, this becomes like
 
 The most polished terminal thing I've [01:00:00] ever seen, like sure, like there's that, there's a library where you can generate these like text image type things that some people use, but those, those pale in comparison to what they're doing on this project. So if you ever wanted to make a very pretty CLI with Python, go check out, uh, what's it called?
 
-Effect effects, just 
+Effect effects, just
 
-terminal text effect. Yeah, I highly suggest you go, go look at the website and the show notes. Cause it's a fun scroll through. ~~Okay. I'm done.~~ 
+terminal text effect. Yeah, I highly suggest you go, go look at the website and the show notes. Cause it's a fun scroll through. ~~Okay. I'm done.~~
 
 **Jason:** Nice.
 
-**Andrew:** Next up we have Chidori. 
+**Andrew:** Next up we have Chidori.
 
 
 #### [01:00:32] Tool Tips: Chidori and One Sec
@@ -597,51 +597,51 @@ Um, so, uh, Colton's working on this, uh, startup called a thousand birds. It's 
 
 Uh, membrane, uh, there are like some parallels and the kinds of work that we're doing, but because this is like really focused on, uh, Agents and LMs. I thought it was a, an interesting thing to share for this one.
 
-**Andrew:** This reminds me of last episode a little bit. Cause like [01:02:00] Dagger almost, I see what he was saying about LLMs and Dagger working really well together, where you could create these big workflows that are basically all cached based on the inputs and outputs. Pretty cool. Uh, last up, we have one sec. 
+**Andrew:** This reminds me of last episode a little bit. Cause like [01:02:00] Dagger almost, I see what he was saying about LLMs and Dagger working really well together, where you could create these big workflows that are basically all cached based on the inputs and outputs. Pretty cool. Uh, last up, we have one sec.
 
 **Jason:** I mean, if anyone who follows me on Twitter knows, I post a ton. And, uh, that is despite using 1sec. Basically what 1sec does is it just Makes you take like a deep breath before you open any apps. And it really helps manage a lot of distractions when I'm, when I'm building things. And so I have a set to like, every time I open up Twitter, the next time I open up Twitter, it takes like 0.
 
-1 seconds longer to open up the app. And, uh, you know, it's, it's pretty funny, but it actually makes a meaningful difference in my 
+1 seconds longer to open up the app. And, uh, you know, it's, it's pretty funny, but it actually makes a meaningful difference in my
 
-productivity. 
+productivity.
 
-**Justin:** Yeah. I'm a fan. 
+**Justin:** Yeah. I'm a fan.
 
-**Jason:** Oh Yeah. You use them. 
+**Jason:** Oh Yeah. You use them.
 
-**Justin:** Yeah. Yeah. 
+**Justin:** Yeah. Yeah.
 
-**Andrew:** So, so you use this and we're able to post that many times on Twitter in 
+**Andrew:** So, so you use this and we're able to post that many times on Twitter in
 
-the last year. 
+the last year.
 
-**Jason:** Yeah. 
+**Jason:** Yeah.
 
-I just use the laptop. 
+I just use the laptop.
 
-**Andrew:** Oh, you just use your laptop. There you go. Can get around any system. 
+**Andrew:** Oh, you just use your laptop. There you go. Can get around any system.
 
-**Jason:** Exactly. Exactly. Well, [01:03:00] I got like hand issues now, so I just got to make sure I'm not on my phone. 
+**Jason:** Exactly. Exactly. Well, [01:03:00] I got like hand issues now, so I just got to make sure I'm not on my phone.
 
 **Justin:** One sec is a lot better than Apple's like built in sort of screen time, because there's always a way to skip it. And you just like build a habit. It's like, Oh, pop up, skip, you know? And then this like, at least forces you, it still lets you do the thing, but it like forces you to like pause for a few seconds.
 
-And that usually that initial dopamine craving that you get, you like get a chance to realize like, Oh, I'm monkey brain right now. I can like not do 
+And that usually that initial dopamine craving that you get, you like get a chance to realize like, Oh, I'm monkey brain right now. I can like not do
 
-this. 
+this.
 
-**Jason:** Yeah, 
+**Jason:** Yeah,
 
 you're just like pressing it really hard.
 
-**Justin:** Yeah, yeah, exactly. 
+**Justin:** Yeah, yeah, exactly.
 
 **Andrew:** Cool. Well, that wraps it up for tool tips and for the episode. Thanks for coming on Jason and teaching us all about, uh, LLMs and how to use them and what all the acronyms mean. So Thanks again for coming on.
 
-**Jason:** Thanks man. That was a blast. 
+**Jason:** Thanks man. That was a blast.
 
-Thanks for having me. 
+Thanks for having me.
 
-**Justin:** Yeah. Thanks, Jason. This has been, this has been really interesting. And, uh, yeah, uh, you're doing a lot of cool work. Uh, we'd love to see it as it develops. 
+**Justin:** Yeah. Thanks, Jason. This has been, this has been really interesting. And, uh, yeah, uh, you're doing a lot of cool work. Uh, we'd love to see it as it develops.
 
 **Jason:** ~~Yeah, it should be a good time. We just like wrote a bunch of different, uh, blog posts and do a ~~
 

--- a/pages/episode/103.mdx
+++ b/pages/episode/103.mdx
@@ -3,6 +3,7 @@ title: Naman Goel - StyleX
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Naman-Goel---StyleX-e2kv5qt
 youtube: https://www.youtube.com/watch?v=34TvzOdkw0I
 tags: technology, react, stylex, css, javascript, webpack, babel, tailwind, atomic styles, stylis, styling, build tools, bundler, flow, typescript, swift, rust
+sponsor: Clerk
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/104.mdx
+++ b/pages/episode/104.mdx
@@ -3,6 +3,7 @@ title: Lu Wilson - TodePond, TLDraw, and the Future of Software Interaction
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Lu-Wilson---TodePond--TLDraw--and-the-Future-of-Software-Interaction-e2l7bli
 youtube: https://www.youtube.com/watch?v=4ShQquWa7Iw
 tags: technology, software, ai, creative coding, tldraw, ink, switch, future of computing, canvas, llm
+sponsor: Clerk
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/105.mdx
+++ b/pages/episode/105.mdx
@@ -3,6 +3,7 @@ title: James Arthur - ElectricSQL
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/James-Arthur---ElectricSQL-e2loud4
 youtube: https://www.youtube.com/watch?v=EY9zs3z6jCE
 tags: technology, react, localfirst, crdt, postgres, browser, javascript, typescript, databases
+sponsor: Clerk
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/106.mdx
+++ b/pages/episode/106.mdx
@@ -3,6 +3,7 @@ title: Robby Russell - oh my zsh, Planet Argon
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Robby-Russell---oh-my-zsh--Planet-Argon-e2m0sfg
 youtube: https://www.youtube.com/watch?v=d4Z4ccwfVhM
 tags: terminal, zsh, oh my zsh, shell, terminal emulator, linux, mac, windows, command line, bash, zsh, shell script, script, terminal, developer tools, podcast, software development, programming, ruby
+sponsor: Clerk
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/108.mdx
+++ b/pages/episode/108.mdx
@@ -1,9 +1,9 @@
 ---
 title: Nicholas C. Zakas - ESLint
-sponsor: MUX
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Nicholas-C--Zakas---ESLint-e2mqm4l
 youtube: https://www.youtube.com/watch?v=m9Oo_hI4EjI
 tags: javascript, eslint, linting, typescript, javascript-linting, static-analysis, lint, linter, code-quality, code-analysis, static-code-analysis, static-code-analysis-tools, javascript-static-code-analysis, javascript-static-code-analysis-tools, typescript-static-code-analysis, typescript-static-code-analysis-tools
+sponsor: MUX
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -45,9 +45,9 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 {/* TAB: TRANSCRIPT */}
 
-**Nicholas C. Zakas:** [00:00:00] ESLint didn't win because it was fastest. Oops. If there's something that you want in it and it's not there, you can go off and build it yourself and not have to wait for the core team to do it. that customizability is the key feature 
+**Nicholas C. Zakas:** [00:00:00] ESLint didn't win because it was fastest. Oops. If there's something that you want in it and it's not there, you can go off and build it yourself and not have to wait for the core team to do it. that customizability is the key feature
 
-**Nicholas C. Zakas:** That really made ESLint popular​ 
+**Nicholas C. Zakas:** That really made ESLint popular​
 
 **Andrew:** Hello, welcome to the DevTools FM podcast. This is a podcast about developer tools and the people who make them. I'm Andrew. And this is my cohost, Justin.
 
@@ -59,7 +59,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** Yeah, that's awesome. I, uh, it's, I mean, it's hard to understate kind of like the impact that you've had because there's been multiple points in my career, you know, besides just ES Lint that I've touched either tools that you've built or frameworks that you've helped design or like read some of your books or like, you know, so it's, it's really, you know, really, really cool.
 
-**Justin:** Kind of a big honor to, uh, to chat with you. 
+**Justin:** Kind of a big honor to, uh, to chat with you.
 
 
 #### [00:01:50] The Birth of ESLint
@@ -93,7 +93,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 #### [00:06:54] Ad
 
-**Andrew:** We'd like to stop and thank our new sponsor for the week, Mux. 
+**Andrew:** We'd like to stop and thank our new sponsor for the week, Mux.
 
 **Andrew:** If you've ever tried to build an app that includes [00:07:00] video, you'll know it is no easy task. From storage to streaming to quality to even the player. There's so much to get right, and it's all very hard to do at scale. I know this from working at Descript, where we've had to build out our own video infrastructure. With Mux, you don't have to do any of that.
 
@@ -146,7 +146,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Andrew:** It's very similar to the, the inception of ESLint where you had to do that stuff for JS hint users. Like to win over the whole crowd, you need to emulate what's already there to a point.
 
-**Justin:** So, uh, we really want to talk more about, like, the future of ESLint and sort of some of the things you have planned. ~~Uh,~~ but before we transition to that, I'd just like to sort of talk about you a little bit more. ~~Um,~~ 
+**Justin:** So, uh, we really want to talk more about, like, the future of ESLint and sort of some of the things you have planned. ~~Uh,~~ but before we transition to that, I'd just like to sort of talk about you a little bit more. ~~Um,~~
 
 
 #### [00:15:47] Nicholas Zakas' Personal Health Journey
@@ -189,7 +189,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** And I think it's like, it's important as an industry that we don't. [00:23:00] forget, you know, that there are people who even doing really good, really profound work are sort of struggling with these health issues. So thanks again for your story. And you heard this folks. If you get bit by a tick and you have a bullseye rash, please, uh, go to the doctor, that's important. ~~Cool. With that, let, Oh, go ahead, Andrew. Go ahead.~~
 
-**Andrew:** ~~Uh, ~~I'll also thank you for sharing. Uh, I haven't dealt with chronic health issues, but I, I really respect the, the struggle. Like that seems like it was an immense challenge to overcome. ~~Um,~~ 
+**Andrew:** ~~Uh, ~~I'll also thank you for sharing. Uh, I haven't dealt with chronic health issues, but I, I really respect the, the struggle. Like that seems like it was an immense challenge to overcome. ~~Um,~~
 
 
 #### [00:23:25] Introduction to FlatConfig in ESLint 9
@@ -222,7 +222,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Nicholas C. Zakas:** And then sometimes they would be installed and sometimes they wouldn't be. And most of the problems that people would come to us with were errors about loading those plugins. Because they would get an error message that said ESLint couldn't find whatever plugin to load. And they couldn't figure out how to fix that.
 
-**Nicholas C. Zakas:** And we couldn't figure out how to fix that. It's like we were trying our best to hack into the Node. js module loading system, basically recreating our own version of that inside of ESLint, which had all kinds of edge cases and all kinds of problems. And so that was one of the big things that we wanted to get rid of.[00:29:00] 
+**Nicholas C. Zakas:** And we couldn't figure out how to fix that. It's like we were trying our best to hack into the Node. js module loading system, basically recreating our own version of that inside of ESLint, which had all kinds of edge cases and all kinds of problems. And so that was one of the big things that we wanted to get rid of.[00:29:00]
 
 **Nicholas C. Zakas:** is we didn't want to have a custom way to load in other files. We just wanted you to use import inside a file yourself.~~ Um,~~ so that was one category of problem that was really difficult to deal with. Um, and another one is people didn't understand why they were getting certain results. Like, why is this lint rule enabled?
 
@@ -356,7 +356,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Nicholas C. Zakas:** It keeps obsoleting other things that were supposed to replace it. So let's be mindful of that. Let's laser focus on vanilla JavaScript and just see where we can go from there.
 
-**Justin:** Yeah, makes total sense. 
+**Justin:** Yeah, makes total sense.
 
 
 #### [00:56:42] Vision for the Future of Linting
@@ -389,4 +389,4 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** And yeah, just thank you for all the hard work that you've put in over the years on this. It's a, it's super, super valuable for the ecosystem.
 
-**Nicholas C. Zakas:** Well, thank you guys. I mean, it's feedback from the community that keeps us going. [01:01:00] So keep it coming. 
+**Nicholas C. Zakas:** Well, thank you guys. I mean, it's feedback from the community that keeps us going. [01:01:00] So keep it coming.

--- a/pages/episode/108.mdx
+++ b/pages/episode/108.mdx
@@ -1,5 +1,6 @@
 ---
 title: Nicholas C. Zakas - ESLint
+sponsor: MUX
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Nicholas-C--Zakas---ESLint-e2mqm4l
 youtube: https://www.youtube.com/watch?v=m9Oo_hI4EjI
 tags: javascript, eslint, linting, typescript, javascript-linting, static-analysis, lint, linter, code-quality, code-analysis, static-code-analysis, static-code-analysis-tools, javascript-static-code-analysis, javascript-static-code-analysis-tools, typescript-static-code-analysis, typescript-static-code-analysis-tools

--- a/pages/episode/109.mdx
+++ b/pages/episode/109.mdx
@@ -2,7 +2,8 @@
 title: Richard Feldman - RockLang, Zed
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Richard-Feldman---Zed--RockLang---Elm-but-for-everywhere-e2n1vl5
 youtube: https://www.youtube.com/watch?v=s--2X0kwe4Y
-tags: programming, rocklang, zed, functional, programming language, functional programming, rust, zig, typescript, elm, 
+tags: programming, rocklang, zed, functional, programming language, functional programming, rust, zig, typescript, elm,
+sponsor: MUX 
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/110.mdx
+++ b/pages/episode/110.mdx
@@ -1,5 +1,6 @@
 ---
 title: Brandon Roberts - Angular, Front-End Frameworks, and OpenSauced 
+sponsor: MUX
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Brandon-Roberts---Angular--Front-End-Frameworks--and-OpenSauced-e2nb0vd
 youtube: https://www.youtube.com/watch?v=mX5oEf_wy7k
 tags: angular, front-end frameworks, open source, open sauced, ngrx, next.js, astro, vite, nitro, analog, brandon roberts

--- a/pages/episode/110.mdx
+++ b/pages/episode/110.mdx
@@ -1,9 +1,9 @@
 ---
-title: Brandon Roberts - Angular, Front-End Frameworks, and OpenSauced 
-sponsor: MUX
+title: Brandon Roberts - Angular, Front-End Frameworks, and OpenSauced
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Brandon-Roberts---Angular--Front-End-Frameworks--and-OpenSauced-e2nb0vd
 youtube: https://www.youtube.com/watch?v=mX5oEf_wy7k
 tags: angular, front-end frameworks, open source, open sauced, ngrx, next.js, astro, vite, nitro, analog, brandon roberts
+sponsor: MUX
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -48,7 +48,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 {/* TAB: TRANSCRIPT */}
 
-**Brandon:** [00:00:00] I would like to see more collaboration across the frameworks. Vite is like a shining example of what happens when you have like a solid foundation that everybody can use and we can have these discussions about features that we're building or features that we want without, Hey, my thing is better than yours 
+**Brandon:** [00:00:00] I would like to see more collaboration across the frameworks. Vite is like a shining example of what happens when you have like a solid foundation that everybody can use and we can have these discussions about features that we're building or features that we want without, Hey, my thing is better than yours
 
 #### [00:00:16] Introduction
 
@@ -62,7 +62,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** So you're the creator of analog JS. Uh, we're really excited to talk about that. Um, you've done some, uh, Work [00:01:00] around maintaining NGRX. Uh, so we're excited to sort of dig into that ecosystem a little bit Um, and you're working at opensauced. So we had uh, brian douglas on bdougie on A little while back and it was a super fun episode and really love what you're building there So excited to talk about that too before we dig in.
 
-**Justin:** Would you like to tell our listeners any more about yourself? 
+**Justin:** Would you like to tell our listeners any more about yourself?
 
 **Brandon:** Yeah
 
@@ -70,7 +70,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Brandon:** I don't know if people actually do anything with people, following people and get up, but I'm on there. I'm on LinkedIn. I'm on all the places. Uh, but yeah, it mostly find me on there ranting about something, uh, sometimes. ~~So,~~
 
-**Andrew:** That that's actually a good segue. Uh, the place you work at is a place that's trying to make GitHub better. One of the things that GitHub does suck at is why would you follow people? Like [00:02:00] they don't even surface a good way to use that information. 
+**Andrew:** That that's actually a good segue. Uh, the place you work at is a place that's trying to make GitHub better. One of the things that GitHub does suck at is why would you follow people? Like [00:02:00] they don't even surface a good way to use that information.
 
 
 #### [00:02:03] Open Sauced Overview
@@ -121,7 +121,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** What sort of problems y'all are seeking to solve by providing, you know, your solution.
 
-**Brandon:** Yeah. 
+**Brandon:** Yeah.
 
 
 #### [00:08:40] Challenges in Open Source
@@ -146,7 +146,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** ~~Awesome. Andrew, you want to take the next one?~~
 
-**Andrew:** ~~Sure. ~~Switching gears [00:12:00] a little bit. Let's talk about some of the open source that you help maintain. 
+**Andrew:** ~~Sure. ~~Switching gears [00:12:00] a little bit. Let's talk about some of the open source that you help maintain.
 
 
 #### [00:12:03] Ad
@@ -220,7 +220,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Brandon:** And we talked about like NGRX, uh, also it manages that same state in that way. Everything about managing state is NGRX is synchronous in the moment that you, but you get the value of it through an observable. So that's when you get into like the, the asynchronous parts of it. But, uh, yeah, it's, it simplifies how you, how you interact with data and how you. How you can read that data as far as rendering goes. Like when you get into like side effects and things like that, I think it's, that's when, uh, more things come into play. But, um, at a, at a fundamental level, they serve, they serve different purposes.
 
-**Justin:** Make sense. Cool. Um, so maybe let's switch over and talk about, uh, another open source project that you're working on. 
+**Justin:** Make sense. Cool. Um, so maybe let's switch over and talk about, uh, another open source project that you're working on.
 
 
 #### [00:22:56] Analog: The Next.js for Angular
@@ -229,11 +229,11 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Brandon:** One might say I'm addicted to [00:23:00] open source projects. No,
 
-**Brandon:** that 
+**Brandon:** that
 
 **Justin:** at a good company for it.
 
-**Justin:** I'm sure you have a really, really good score. 
+**Justin:** I'm sure you have a really, really good score.
 
 **Brandon:** Yes. Well, I, I check my score every now. I don't take my score every day, but, uh, but yes, I do. I do check the, to make sure that where we, where we are in the landscape of, of open source projects also.
 
@@ -294,7 +294,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Brandon:** So that was how, how I kind of got started, uh, as far as the plugin goes. And then just seeing how. Every tool out there has some sort of V integration or things like that, that we could kind of build on top of, uh, I knew that was going to be big. So that's how, that's how, that's what kind of fueled the initial, the initial work after that.
 
-**Andrew:** As Justin said, a lot of different meta framework authors are choosing Vite to power their meta frameworks. And I think along with that, they've built a bunch of tools to help make that easier. I was going through the docs and I saw both Nitro and Astro mentioned. 
+**Andrew:** As Justin said, a lot of different meta framework authors are choosing Vite to power their meta frameworks. And I think along with that, they've built a bunch of tools to help make that easier. I was going through the docs and I saw both Nitro and Astro mentioned.
 
 
 #### [00:32:46] Leveraging Nitro for Server-Side Capabilities
@@ -319,7 +319,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** I really love to see this kind of convergence. Um, I mean, using the, using Nitro, um, just trying, like, it's funny cause there's not really as much difference between these meta frameworks as like you would think. Um, they all kind of try to do similar things and there's like some pretty large maintenance burdens and developing these things from scratch.
 
-**Justin:** So it is nice to see a lot of reuse here. 
+**Justin:** So it is nice to see a lot of reuse here.
 
 **Brandon:** Yeah, I definitely, I definitely saw that as, as a bonus being able to, because [00:36:00] then in, in the, in the same way I get to say, Hey, we support all these things out of the box, you know, already, uh, and it's because it was like the typical open source model, like we're standing on the shoulders of giants, not to be cliche, but Um, they have already invested a bunch of work in how Nitro works.
 
@@ -353,7 +353,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** So it's like, did you, uh, ~~yeah.~~
 
-**Justin:** What were your hardest 
+**Justin:** What were your hardest
 
 **Justin:** challenges there?
 
@@ -400,7 +400,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Brandon:** So, um, but this was, uh, something I think could live in analog, uh, pretty reasonably well and allow us to kind of play around with that and see what, what that, what that potential future could look like.
 
-**Andrew:** ~~Um,~~ 
+**Andrew:** ~~Um,~~
 
 
 #### [00:48:14] Future Directions for Angular and Front-End Frameworks
@@ -439,25 +439,25 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Andrew:** I can already people hear the people on Twitter complaining that we have a new iteration of all our frameworks again, ~~but the, ~~
 
-**Brandon:** Hey, they're going to do it, they're going to do it anyway, so we might as well, uh, get some of the things that will, that will outlast some of the frameworks while we're at it. 
+**Brandon:** Hey, they're going to do it, they're going to do it anyway, so we might as well, uh, get some of the things that will, that will outlast some of the frameworks while we're at it.
 
-**Andrew:** True. 
+**Andrew:** True.
 
 
 #### [00:53:56] Closing Thoughts and Reflections
 
-**Andrew:** And with that, that wraps up our questions for this week. Thanks for coming on, Brandon. This was [00:54:00] a really fun dive into all things Angular, something we haven't done all that much on this podcast. So thanks for coming on. 
+**Andrew:** And with that, that wraps up our questions for this week. Thanks for coming on, Brandon. This was [00:54:00] a really fun dive into all things Angular, something we haven't done all that much on this podcast. So thanks for coming on.
 
 **Brandon:** Yeah,
 
-**Brandon:** sure. Thanks for 
+**Brandon:** sure. Thanks for
 
-**Brandon:** having me. 
+**Brandon:** having me.
 
-**Justin:** Yeah, to echo that, thanks again, Brandon, uh, uh, you know, so funny that you, uh, are in the same town that I went in college in. So if I'm ever in the area, I'll hit you up, maybe we can grab a beer or something, but thanks for coming 
+**Justin:** Yeah, to echo that, thanks again, Brandon, uh, uh, you know, so funny that you, uh, are in the same town that I went in college in. So if I'm ever in the area, I'll hit you up, maybe we can grab a beer or something, but thanks for coming
 
-**Justin:** on. 
+**Justin:** on.
 
-**Brandon:** please please do. 
+**Brandon:** please please do.
 
-**Justin:** Cool. Sounds good. 
+**Justin:** Cool. Sounds good.

--- a/pages/episode/111.mdx
+++ b/pages/episode/111.mdx
@@ -1,9 +1,9 @@
 ---
 title: Jordan Harband - Npm Ecosystem, HeroDevs
-sponsor: MUX
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Jordan-Harband---Npm-Ecosystem--HeroDevs-e2njf3m
 youtube: https://www.youtube.com/watch?v=iNV53u-rzqo
 tags: npm, ecosystem, herodevs, open source, front end, frameworks, node, legacy, security, vulnerabilities, npm, package, ecosystem, javascript
+sponsor: MUX
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -51,7 +51,7 @@ Jordan: I've developed a sort of human centered approach, I would rather inconve
 
 Jordan: it's fine if people don't share that ethos but, that decision means that I want to maximize compatibility for my packages.
 
-Jordan: no matter what version, of Node you're using, you can upgrade my packages to the latest and ship it, 
+Jordan: no matter what version, of Node you're using, you can upgrade my packages to the latest and ship it,
 
 #### [00:00:21] Introduction
 
@@ -59,21 +59,21 @@ Andrew: Hello, welcome to the DevTools FM podcast. This is a podcast about devel
 
 Justin: We're really excited to have Jordan Harband on with us. Uh, Jordan, you are a legend in the JavaScript ecosystem. Uh, so it's really great to have you here. Uh, I mean, you've done a lot and I just want to highlight a few things. So you're on the TC39, uh, which is incredibly cool. I'm really excited to talk about that.
 
-Justin: Uh, you're, are you still working with Hero Devs? 
+Justin: Uh, you're, are you still working with Hero Devs?
 
 Jordan: Yeah, I started in December.
 
 Justin: okay, great. So. Oh, fantastic. So you're working with hero devs, an organization that helps, uh, companies, uh, who depend on dependencies that are no longer supported, which is a very admirable goal, you're part of the open JS foundation, you've done a ton of stuff.
 
-Justin: Uh, I am excited to dig into all of that, but before we dive any more, is there anything else you'd like our audience to know 
+Justin: Uh, I am excited to dig into all of that, but before we dive any more, is there anything else you'd like our audience to know
 
-Justin: about yourself? 
+Justin: about yourself?
 
 Jordan: no, I mean, I'm happy to be here. I, I appreciate, you know, everyone who uses my open source stuff or benefits for any of my contributions. And, um, I hope that, uh, you know, the, I think the best, the most impactful thing for, uh, open source maintainers remains getting, uh, Your employer to contribute in some way, whether it's through sponsors or Tidelift or thanks.
 
 Jordan: dev or something like that. So, um, if you want to help folks, not just me, but anyone, um, please advocate for them to do that.
 
-Andrew: That's a great message. Uh, so I think there are a set of profile pictures on GitHub and NPM, uh, that like I've seen everywhere and yours is one of them. I've seen you on countless GitHub issues, whether it's steering committee things or like a. A litany of ESLint issues. 
+Andrew: That's a great message. Uh, so I think there are a set of profile pictures on GitHub and NPM, uh, that like I've seen everywhere and yours is one of them. I've seen you on countless GitHub issues, whether it's steering committee things or like a. A litany of ESLint issues.
 
 
 #### [00:02:07] Jordan's Journey into Open Source
@@ -98,7 +98,7 @@ Jordan: So anytime you update anything, you often have to update a bunch of othe
 
 Jordan: And so not only does that, that world encourage people, I think to avoid dependencies, but it also. Limits how much kind of reusability you can get out of your code. And I, so I loved, I like, I found myself loving that aspect of NPM and, um, just kept going and then, uh, you know, part of that was maintaining polyfill packages, ES5 shim and ES6 shim, and then eventually I started making polyfills that were single standalone packages, uh, and that also is what led me into TC39.
 
-Justin: That's awesome. So there's like two parts of that, that I want to dig into a little bit more. 
+Justin: That's awesome. So there's like two parts of that, that I want to dig into a little bit more.
 
 
 #### [00:05:44] Challenges of Managing Open Source Projects
@@ -113,27 +113,27 @@ Jordan: There's every now and then there's a really important thing and I want t
 
 Jordan: That's a big deal. Versus if it's just in this big, long, undifferentiated list, uh, it, that doesn't really work for me. So, but that, that's how I do it. And then, uh, I also have, you know, Slack and IRC and discord and email and all the things. And, um, yeah, I think just my particular brand of, you know, neuro divergence or whatever is it lends itself well to lots of different multiple, you know, ongoing threads and, um, You know, there's that thing that says that like only 10 percent of people are good at multitasking, but everybody thinks they're in that 10%.
 
-Jordan: And, you know, I think I'm in that 10%, but who knows? 
+Jordan: And, you know, I think I'm in that 10%, but who knows?
 
 
 #### [00:07:34] Ad
 
-Justin: We'd like to thank Mux for sponsoring our podcast. This week. Mux is a video platform for developers that enables teams to ship video based products faster than ever before. If you're looking to add live streaming or stream on demand, video content to your product, mux has simple APIs that enable you to ship that in days, not weeks. 
+Justin: We'd like to thank Mux for sponsoring our podcast. This week. Mux is a video platform for developers that enables teams to ship video based products faster than ever before. If you're looking to add live streaming or stream on demand, video content to your product, mux has simple APIs that enable you to ship that in days, not weeks.
 
-Justin: They have tooling built for every stage of the video pipeline, whether it's simplifying video uploads, Intelligently determining the resolution of video playback for your users, providing editing features to programmatically generate social clips or add watermarks, allowing you to easily generate thumbnails for video assets, and even getting in-depth analytics on how users are engaging with your video content. 
+Justin: They have tooling built for every stage of the video pipeline, whether it's simplifying video uploads, Intelligently determining the resolution of video playback for your users, providing editing features to programmatically generate social clips or add watermarks, allowing you to easily generate thumbnails for video assets, and even getting in-depth analytics on how users are engaging with your video content.
 
-Justin: There's guidance and their docs for integrating with major web frameworks, they have SDKs in most popular programming languages. They are a very extensive platform that will help you ship your video products faster. So, if that sounds interesting to you go check them out at mux.com that's M U X dot com. 
+Justin: There's guidance and their docs for integrating with major web frameworks, they have SDKs in most popular programming languages. They are a very extensive platform that will help you ship your video products faster. So, if that sounds interesting to you go check them out at mux.com that's M U X dot com.
 
-Justin: yeah. One other question on the topic that you covered before. 
+Justin: yeah. One other question on the topic that you covered before.
 
 
 #### [00:08:43] Debating the NPM Ecosystem
 
 Justin: Um, So we were talking about like the shape of NPM, how you feel like this is like one of the only, uh, sort of package registries that's not broken. Uh, and there are some people who feel very strongly that, uh, the incentives of NPM actually incentivize broken.
 
-Justin: Bad behavior. It's like, Oh, we have too many dependencies. Oh, there's like too much, um, like fragility and, you know, risk involved and, you know, potentially for like supply chain attacks and things. And left pad incident is like a very popular thing that people, um, bring up. So I'm curious to hear about like your take on this sort of like, uh, alternative perspective on NPM and it's 
+Justin: Bad behavior. It's like, Oh, we have too many dependencies. Oh, there's like too much, um, like fragility and, you know, risk involved and, you know, potentially for like supply chain attacks and things. And left pad incident is like a very popular thing that people, um, bring up. So I'm curious to hear about like your take on this sort of like, uh, alternative perspective on NPM and it's
 
-Justin: shape. 
+Justin: shape.
 
 Jordan: Well, humans in general, myself included, we like to paint things with a broad brush, especially when we're going for rhetorical impact on like, whether it's on a GitHub, you know, comment or a Twitter thread or whatever. So it's often oversimplified in lots of different directions. And I am very guilty of that.
 
@@ -185,7 +185,7 @@ Jordan: Um, and that's, that's informed by, you know, just my, my personal lived
 
 Jordan: Like I think that, uh, it's just too easy to oversimplify and paint these things with one, with your favorite brush, whatever that is, and then say, therefore a is bad and B is good. And, um, and that's a fine conversation to be had when it's just a kind of didactic argument. But, um, obviously when it turns into people, you know, being jerks or harassing people or generating internet outrage, then that's perhaps not the most productive solution.
 
-Andrew: Yeah, for sure. 
+Andrew: Yeah, for sure.
 
 
 #### [00:17:40] Inside TC39: Shaping JavaScript's Future
@@ -202,11 +202,11 @@ Jordan: Um, I think the thing I'm weakest on is like grammar and parsing and, yo
 
 Jordan: How to describe something.
 
-Justin: Of the things that you've been involved with, with the TC39, what's, what like proposal or work that you've done are you most proud of? 
+Justin: Of the things that you've been involved with, with the TC39, what's, what like proposal or work that you've done are you most proud of?
 
 Jordan: Um, Good question. The things that have already landed, So I think, there's a bunch of stuff I'm happy is there, like object. values and entries was my proposal. Um, I took it over from someone else, but nonetheless. And then, uh, So there's a lot of things like that that are useful. But I think that the one that I'm the most proud of so far that's landed is one that I actually designed myself, which was a match all string dot prototype dot match all, um, because I kept occasionally running into this problem of like, I have a global regex that also has capturing groups and I want to get all of them.
 
-Jordan: And, um, so I made the proposal to, to address it and, um, That one seems to be there. I haven't heard any controversy about like controversy or complaints about it. And I've gotten some, you know, gratitude about it. And, and that one was a hundred percent me. And so I'm pretty proud of that one. 
+Jordan: And, um, so I made the proposal to, to address it and, um, That one seems to be there. I haven't heard any controversy about like controversy or complaints about it. And I've gotten some, you know, gratitude about it. And, and that one was a hundred percent me. And so I'm pretty proud of that one.
 
 Andrew: I love both of those JavaScript features. I use them quite, I use the former quite a lot. Um, so you're. You're like main ethos with a lot of the package stuff is I don't want prototypes to be polluted. How does that extend to these TC 39 proposals? So like in the case of match all, is it like you're worried that someone will overwrite match all to do different things?
 
@@ -226,13 +226,13 @@ Jordan: And so they have to lock things down and, you know, so there, there's a 
 
 Jordan: And sometimes that means things don't advance or they're stalled for a long time, but, part of the danger of JavaScript in particular, which is that, uh, in another language, you could remove something later, uh, in JavaScript. You never can. We, the number one rule is we do not break the web.
 
-Jordan: So like pretty much anything that gets adoption on the web is, is there forever. So it's, it's. Most software choices, you, if you really screw up, there's a timeline after which your screw up is gone. And with, with JavaScript, there is no timeline. It is there forever, 
+Jordan: So like pretty much anything that gets adoption on the web is, is there forever. So it's, it's. Most software choices, you, if you really screw up, there's a timeline after which your screw up is gone. And with, with JavaScript, there is no timeline. It is there forever,
 
 Andrew: Yep. There's always that one guy who misspelled refer, and now we all have to misspell it forevermore.
 
-Jordan: forever. Yep, that's right. You got it. 
+Jordan: forever. Yep, that's right. You got it.
 
-Justin: Are there any other, uh, big, maybe like accidents or things that y'all wish would not have landed that, but that did and had like unconsequent or like unintended 
+Justin: Are there any other, uh, big, maybe like accidents or things that y'all wish would not have landed that, but that did and had like unconsequent or like unintended
 
 Justin: side effects?
 
@@ -246,9 +246,9 @@ Jordan: Um, there's also some of the decisions made with class, um, that kind of
 
 Jordan: Um, and so like what, what they would have preferred to happen is that it like, if it can't, you know, if the thing is frozen, it's like a site, it makes a data property or I don't know, something like that. But there's, there's like little edge case, things like that, that have ended up affecting the language's consistency in a lot of different ways.
 
-Jordan: And, um, the committee has to balance pragmatism with idealism. Otherwise we wouldn't be able to get anything done. 
+Jordan: And, um, the committee has to balance pragmatism with idealism. Otherwise we wouldn't be able to get anything done.
 
-Andrew: Yeah, it's a unique constraint of the web that we can't really break anything ever. It's like, it's, it's, it's probably astounding to any other platform, but I think that really, uh, is a nice transition into the next part of our discussion where, uh, we discuss your opinions about legacy support. 
+Andrew: Yeah, it's a unique constraint of the web that we can't really break anything ever. It's like, it's, it's, it's probably astounding to any other platform, but I think that really, uh, is a nice transition into the next part of our discussion where, uh, we discuss your opinions about legacy support.
 
 
 #### [00:26:22] The Importance of Legacy Support in Node.js
@@ -283,7 +283,7 @@ Jordan: Right. Um, you breaking your website is not going to force them to upgra
 
 Jordan: And it's fine if people don't share that, that preference, that, you know, that ethos or whatever, but, um, that decision means that I want to maximize compatibility for my packages. I want to make it easier. Like you, you can use. No matter what version, like, of Node you're using, you can upgrade my packages to the latest and ship it, and then you don't have to deal with any of my code when you're actually upgrading Node.
 
-Jordan: And that makes upgrading Node easier. That is the opposite of holding the ecosystem back, in my view. 
+Jordan: And that makes upgrading Node easier. That is the opposite of holding the ecosystem back, in my view.
 
 Andrew: Yeah, I can definitely resonate with the upgrading packages story. Like 10 out of 10 times it, it all, it is always a breaking change somewhere else that's holding me back, like upgrading more than one dependency at a time is just fraught with terror. Uh, so the ability to only do it one at a time is pretty big.
 
@@ -304,7 +304,7 @@ Jordan: And it'll show you the like last week's worth of downloads on that packa
 
 Jordan: And in that case, what that means empirically is the ecosystem did not want the breaking change enough. To upgrade to it. And the ecosystem here might be lots of people, but it also might be 10 people who are, you know, who have popular packages that are like feeding the download, you know, priming the downloads for that, for that transit dependency.
 
-Jordan: But nonetheless, that's, that's. That's the, your consumer, right? And so if your consumer doesn't want to upgrade to you, you screwed up and you can choose to double, to not fix that. Or you can choose to try and fix that. Um, or you can choose to avoid the problem entirely by not doing a breaking change and that is usually what I opt for. 
+Jordan: But nonetheless, that's, that's. That's the, your consumer, right? And so if your consumer doesn't want to upgrade to you, you screwed up and you can choose to double, to not fix that. Or you can choose to try and fix that. Um, or you can choose to avoid the problem entirely by not doing a breaking change and that is usually what I opt for.
 
 Andrew: Yeah, I've definitely been in those package situations in my eye. I've harped on it on this show a lot. ESM versus CJS was such. A mistake on so many levels.
 
@@ -314,14 +314,14 @@ Jordan: And you can go look at that website I mentioned and see how, like the nu
 
 Jordan: And the way to the way to change that isn't to make everybody else's life harder in the meantime. There, there are, there are ways to change that, but it's, that's not it.
 
-Justin: I, I'm curious to sort of like to build off of this conversation. 
+Justin: I, I'm curious to sort of like to build off of this conversation.
 
 
 #### [00:36:57] HeroDevs: Extending the Life of Open Source Projects
 
-Justin: So, uh, we've mentioned a few times you work at hero devs. Um, and so this organization like is very explicitly for extending the life of open source projects. And could you talk a little bit more about like the details of like what that means and like what your day to day kind of 
+Justin: So, uh, we've mentioned a few times you work at hero devs. Um, and so this organization like is very explicitly for extending the life of open source projects. And could you talk a little bit more about like the details of like what that means and like what your day to day kind of
 
-Justin: looks like? 
+Justin: looks like?
 
 Jordan: Yeah. So let's say, um, view, for example, so vue three is out. View two is unsupported. What this means is that there's a security vulnerability in vue two, uh, You've got it. There's no fix for it available. Uh, and the Vue team is not going to fix it. So you are guaranteed to not get a fix for free. Uh, and your choice then is you can upgrade to Vue 3, which if you can, you should, you should use the migration guides, the change logs, like whatever's out there and you should try and upgrade.
 
@@ -360,7 +360,7 @@ Jordan: Right. Like, and the number of people on the planet who have made a livi
 
 Jordan: If they were, then. Then that would become a reasonable conversation to have. I still would claim that that hasn't, is not influencing my decisions. I would, I do these things on packages that have no downloads the same as I do them on packages that have millions. But, um, yeah, if you, I think, but if you, it's, it's also fun to see, uh, the people who have made those accusations, trying to get their own packages, adopted places and increase their download counts.
 
-Jordan: Um, but you know, people can make of that what they will 
+Jordan: Um, but you know, people can make of that what they will
 
 Andrew: Yeah, it is another person in the, in the stack. And it's like, I've found through my open store source work that it is hard. You don't like, it's not something that everybody can stomach for like ever. And like, you've been in the ecosystem for like, I don't, you said 2010, that's 14 years deep in the open source.
 
@@ -376,7 +376,7 @@ Jordan: And that's, it's, uh, you know, there's, there's trade offs, right? Like
 
 Justin: Yeah, I think, um, We'd sort of started off by talking about this before we started recording, but the, the important thing here is like to remember that we all have things that are important to us. There are a bunch of trade offs that we have to make, like you've been saying, and like, um, it's easy to get like dug in on positions and get really heated, but like, You know, we're all just trying to make a software here and like, you know, help people out and especially in the open source community, because it's so, it's such a thankless job already.
 
-Justin: Um, and it's like, it's, it's rough to see people like in that community sort of turn on each other. So, you know, just, just pre facing all this is like, you know, at the end of the day, we all, you know, have things that we're trying to do and we just want to make the ecosystem better. 
+Justin: Um, and it's like, it's, it's rough to see people like in that community sort of turn on each other. So, you know, just, just pre facing all this is like, you know, at the end of the day, we all, you know, have things that we're trying to do and we just want to make the ecosystem better.
 
 Jordan: I would, also add the, uh, Chesterton's fence, I believe is the term, which is, uh, before you take down a fence, you need to understand why it's there. Um, and, and I think that the, and again, I've suffered from this just as much as anyone else, that there's a lot of folks that are relatively new to the industry or young or both.
 
@@ -386,7 +386,7 @@ Jordan: Um, People look at something that's been the, you know, that's like, Oh,
 
 Jordan: Right? Like, uh, I'm always, I can be convinced differently on any of my opinions. It's just, you'd have to present a good enough argument.
 
-Justin: Something I wanted to talk about related to, uh, some of your earlier work and like your current work, uh, talking about, uh, you know, extending legacy support for packages that are no longer actively maintained and trying to make sure that they have security updates. 
+Justin: Something I wanted to talk about related to, uh, some of your earlier work and like your current work, uh, talking about, uh, you know, extending legacy support for packages that are no longer actively maintained and trying to make sure that they have security updates.
 
 
 #### [00:48:14] Automated CVEs and Dependency Management
@@ -421,31 +421,29 @@ Jordan: It will stop the publish and say, Whoa, are you sure? Because when I've 
 
 Jordan: Other than that, it's just Git. I check out the version tag that I'm branching off of, and I cherry pick the commit in and modify it as needed and push it up. And then once the I passes, I publish it.
 
-Andrew: So as we're, uh, as we're wrapping up, um, we always like to ask our guests about, uh, something in the future, future facing question. 
+Andrew: So as we're, uh, as we're wrapping up, um, we always like to ask our guests about, uh, something in the future, future facing question.
 
 
 #### [00:53:32] Future of Package Management in JavaScript
 
 Justin: And for you, um, and, and especially given sort of the topics that we've covered, what do you think about the, what do you think the future of like maybe NPM or more generally, what is the future of package management in JavaScript?
 
-Justin: Like, what does that look like? 
+Justin: Like, what does that look like?
 
 Jordan: Um, okay. I would love to see GitHub start funding things that don't have the letters AI in them, and Again, so that NPM can get the funding it needs. Like, NPM should have like a hundred full time people on it, and I doubt it has more than ten. Um, Um, if that's fixed, then, um, I imagine that the future is just continual improvements to the CLI and continued iteration of like best practices for how to publish packages and it just, you know, things will continue getting better gradually as they have been.
 
 Jordan: Um, yeah, it was, it was a very different world 10 years ago. Um, as if that doesn't happen, then I think it would be on, you know, Like incumbent on the potential competitors to NPM, um, JSR, Volt. sh. Um, and they would have to make a product that interoperates with NPM well enough and provides enough benefit and value to incentivize people to migrate.
 
-Jordan: Um, that is a very tough challenge. And, um, I hope that, that in the event that, uh, GitHub does not, uh, fund NPM properly again. Uh, I would hope that one of them is able to achieve it. For the betterment of all of us. Um, Yeah, 
+Jordan: Um, that is a very tough challenge. And, um, I hope that, that in the event that, uh, GitHub does not, uh, fund NPM properly again. Uh, I would hope that one of them is able to achieve it. For the betterment of all of us. Um, Yeah,
 
 Andrew: Yeah, I'm excited to see what happens with those other ones. And I wholeheartedly agree with MPM. Like even the U. I. Is kind of busted. Sometimes now it's definitely kind of gaining some bit rock.
 
 Jordan: yeah. I mean, every time, all the work the NPM team has done now and over the years, I, I think is great, right? Like I'm like, they do good work. It's just, there's nowhere near enough of them for many years now to do all the good work that's required. Um, so this is not a slight to any of them. It's only a slight to whoever is deciding the budget for that department.
 
-Andrew: Well, that wraps it up for our questions this week. Thanks for coming on Jordan. This was a great conversation around an area in the node ecosystem that doesn't get too much light. So I'm glad you're there holding it up. 
+Andrew: Well, that wraps it up for our questions this week. Thanks for coming on Jordan. This was a great conversation around an area in the node ecosystem that doesn't get too much light. So I'm glad you're there holding it up.
 
-Jordan: Yeah. Thanks for having me. Happy to be here. 
+Jordan: Yeah. Thanks for having me. Happy to be here.
 
-Justin: Yeah. Thanks so much for the conversation. And, uh, yeah, I appreciate your perspective and the sort of wisdom and guidance of having worked in this space for a long time and taking in a lot of considerations for people who quite honestly probably don't get a lot of representation. Um, so appreciate that. 
+Justin: Yeah. Thanks so much for the conversation. And, uh, yeah, I appreciate your perspective and the sort of wisdom and guidance of having worked in this space for a long time and taking in a lot of considerations for people who quite honestly probably don't get a lot of representation. Um, so appreciate that.
 
-​ 
-
-
+​

--- a/pages/episode/111.mdx
+++ b/pages/episode/111.mdx
@@ -1,5 +1,6 @@
 ---
 title: Jordan Harband - Npm Ecosystem, HeroDevs
+sponsor: MUX
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Jordan-Harband---Npm-Ecosystem--HeroDevs-e2njf3m
 youtube: https://www.youtube.com/watch?v=iNV53u-rzqo
 tags: npm, ecosystem, herodevs, open source, front end, frameworks, node, legacy, security, vulnerabilities, npm, package, ecosystem, javascript

--- a/pages/episode/112.mdx
+++ b/pages/episode/112.mdx
@@ -3,6 +3,7 @@ title: Travis Arnold - Omnidoc, Restyle, JSX UI
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Travis-Arnold---Omnidoc--Restyle--JSX-UI-e2nsp4f
 youtube: https://www.youtube.com/watch?v=vd6pm8R3f9k
 tags: javascript, react, typescript, mdx, documentation, performance, state management, server components, restyle, jsx ui
+sponsor: MUX
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/113.mdx
+++ b/pages/episode/113.mdx
@@ -3,6 +3,7 @@ title: Predrag Gruevski - Trustfall, Cargo Semver Checks, and the Future of Quer
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Predrag-Gruevski---Trustfall--Cargo-Server-Checks--and-the-Future-of-Query-Based-Tools-e2o5fju
 youtube: https://www.youtube.com/watch?v=BZSGVCz4ALw
 tags: rust, rustlang, rust-lang, cargo, semver, semantic versioning, versioning, version control, query-based tools, query, queries, database, databases, sql, graphql, trustfall, cargo Semver checks, open source software, oss software, open source software, oss software
+sponsor: MUX
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/114.mdx
+++ b/pages/episode/114.mdx
@@ -3,6 +3,7 @@ title: David Mytton - Console.dev, ArcJet - Enhancing Application Security
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/David-Mytton---Console-dev--ArcJet---Enhancing-Application-Security-e2oegvk
 youtube: https://www.youtube.com/watch?v=evZltUWslgw
 tags: security, console.dev, arcjet, application security, web security, web development, javascript, typescript, react, vue, angular, node, rust, rustlang, rust-lang
+sponsor: MUX
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/115.mdx
+++ b/pages/episode/115.mdx
@@ -1,9 +1,9 @@
 ---
 title: Guido Rosso - Rive, The Graphics Format of the Future
-sponsor: MUX
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Guido-Rosso---Rive--The-Graphics-Format-of-the-Future-e2onnfl
 youtube: https://www.youtube.com/watch?v=P1LsxSf3F8k
 tags: graphics, animation, design, tools, rive, flash, canvas, webgl, html5
+sponsor: MUX
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -33,7 +33,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 [00:00:00] Introduction
 [00:05:31] The Evolution and Inspiration Behind Rive
-[00:08:18] Ad 
+[00:08:18] Ad
 [00:11:46] Rive's Unique Graphics Format and Renderer
 [00:19:42] State Machines: A Designer's Tool
 [00:29:18] Exploring the RIV File Format
@@ -59,7 +59,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Guido:** Uh, no, thanks. Thanks for having me. Um, I guess we'll probably dig, dig into some of it, but, uh, uh, if you're wondering about the name, I am, yes. I am Italian. Italian is my first language. Just grew up gonna international schools all across the world. And yeah, drop, drop the accent pretty early on. I often talk about myself as we, and that's because I have an identical twin and in traveling a lot, like it was always we and, and, uh.
 
-**Guido:** And yeah, my whole life has always been more about we than me. And, and he's, uh, you know, he's my counterpart. He's my, he's my co founder. He's engineer. I'm the designer. That's how this whole concept came across. And we can probably dig into some of that at some point if you want to shout about it, but Yeah, 
+**Guido:** And yeah, my whole life has always been more about we than me. And, and he's, uh, you know, he's my counterpart. He's my, he's my co founder. He's engineer. I'm the designer. That's how this whole concept came across. And we can probably dig into some of that at some point if you want to shout about it, but Yeah,
 
 **Guido:** uh, that's it.
 
@@ -92,7 +92,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** Yeah, I was going to actually had a question lined up to ask you if you took inspiration from Flash. So when I was in high school, I did a lot of stuff in Flash. And it seems like there was like an early part of like the 2000s internet. That was just a lot. Of Flash interactions and animations and these like really interesting dynamic websites that were also really heavy and very clunky, right?
 
-**Justin:** They took forever to load, the internet was slow, the assets were large, 
+**Justin:** They took forever to load, the internet was slow, the assets were large,
 
 **Guido:** Yeah. The format was proprietary. It ran, didn't run well on Macs at all. I mean, even before the whole, you know, Apple drama, like it was almost a joke trying to run flash on a Mac and then they got the Intel processors and it started getting actually a little more serious and functional, but it was always felt like it was a little bit, yeah.
 
@@ -109,7 +109,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 **Guido:** Convert those graphics to code. Like they give us, you know, dev mode and, and, and red lines and guidelines and all these, you know, docs to help define how, how it should be converted to code and yeah, we see it a little differently and it's inspired a lot from flash, which was the idea that the designer gets to build a format that actually runs as opposed to, um, yeah, just a mock up or a prototype.
 
 
-#### [00:08:18] Ad 
+#### [00:08:18] Ad
 
 **Andrew:** We'd like to pause for a moment and thank our sponsor for this week, MUX.
 
@@ -127,7 +127,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Andrew:** You tired of hearing these ads? We'll become a paid member on one of the various channels that we offer it. With that, you'll get the episodes a little bit earlier, and they'll be completely ad free, and you'll also be helping out the podcast a little bit. But if you want to find a different way to help out the podcast, head over to shop.
 
-**Andrew:** devtools. fm where you can buy a hat or a t shirt show your support for the podcast and keep us going a little bit longer. And with that, let's get back to the 
+**Andrew:** devtools. fm where you can buy a hat or a t shirt show your support for the podcast and keep us going a little bit longer. And with that, let's get back to the
 
 **Justin:** Yeah, this is a, it's such a fascinating space. You see it at the like, sort of smaller level with tools like Webflow, right? It's like, you know, and again, these tools existed forever ago. You had like Dreamweaver, like, you know, here's a WYSIWYG site builder. The technology for those have gotten better. So Webflow, you know, there's a lot of people who are like publishing, you know, actual.
 
@@ -141,7 +141,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Guido:** I think that's ultimately what we're trying to do is as tool builders, um, those guys are building, you know, they're focusing very much on like one kind of, uh, platform, which is the web. They're, they're helping designers build a, you know, a, a, a vision that then gets converted or behind the scenes as using the same constraints to build it in code.
 
-**Guido:** Um, and, and, and basically create a website. With Rive, yeah, animation is a part of that, like you were saying, and it, it takes a lot of effort, and the, the vision was different, um, and complementary, I think, to all those platforms, because we want to work with all those platforms, too. 
+**Guido:** Um, and, and, and basically create a website. With Rive, yeah, animation is a part of that, like you were saying, and it, it takes a lot of effort, and the, the vision was different, um, and complementary, I think, to all those platforms, because we want to work with all those platforms, too.
 
 
 #### [00:11:46] Rive's Unique Graphics Format and Renderer
@@ -172,11 +172,11 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Andrew:** I don't know if you know what react is, but it has a very similar,
 
-**Andrew:** like ethos. 
+**Andrew:** like ethos.
 
-**Guido:** Yeah. I'm the designer of the two twins. So less, but I mean, we, I know react, I used with the first version of Rive that me and Luigi built was I did all the front end and react, which he did all the hardcore graphics. Um, but yeah, very, very familiar with react. 
+**Guido:** Yeah. I'm the designer of the two twins. So less, but I mean, we, I know react, I used with the first version of Rive that me and Luigi built was I did all the front end and react, which he did all the hardcore graphics. Um, but yeah, very, very familiar with react.
 
-**Andrew:** yeah, but it gives me like this similar vibe of like, I can render one thing one way, put it across many platforms and like speed up development, taking that a level higher and kind of going beyond code seems super interesting to me. How far beyond it do you go though? Like you have runtime renderers, how like specific to the runtime are, are they like? 
+**Andrew:** yeah, but it gives me like this similar vibe of like, I can render one thing one way, put it across many platforms and like speed up development, taking that a level higher and kind of going beyond code seems super interesting to me. How far beyond it do you go though? Like you have runtime renderers, how like specific to the runtime are, are they like?
 
 **Guido:** So yeah, good question. So we initially supported multiple renders and we still do the runtime still has this philosophy of bring your own renderer. So, for example, on, on, uh, on iOS, you can choose to still use core graphics instead of the Rive renderer. Um, and there's some cases where you have to do that, like to plug into certain parts of iOS and Android, and I think, uh, Vision Pro, there's some parts that, like, need core graphics, like if you're trying, for example, to render a Rive animation in the dock, which you might have seen recently, um, that, that app that went viral, Banana Bin, did you see that?
 
@@ -190,11 +190,11 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Guido:** Nothing particularly crazy, but it's kind of a new way to feather the edges of Strokes and paths, uh, creating glow and kind of blur and shadow effects, but using our novel rendering algorithm, which again is all open source and you can go see how it works. Um, but it's, uh, it's going to be like a new way to do shadows without having to Um, do multiple, and this is where I get a bit out of my element, but like, without multiple draw calls and all that, and it basically is super fast.
 
-**Guido:** So you can, you can kind of blur the edges of a bunch of paths and not get any real performance impact. Um, and so, and so that's the type of stuff that you need our renderer to be able to use it. Um, I feel like I went a little bit off a tangent here on your original question. Feel free to rein me back in. 
+**Guido:** So you can, you can kind of blur the edges of a bunch of paths and not get any real performance impact. Um, and so, and so that's the type of stuff that you need our renderer to be able to use it. Um, I feel like I went a little bit off a tangent here on your original question. Feel free to rein me back in.
 
 **Justin:** That's great. This is so fascinating. It does seem like the design space. Is so broad. I mean, the product area. So it's like, I mean, one, you have to have a really good editor like that is table stakes for any animation. And like, just doing that alone is a super, super hard problem. And then when you're doing cross platform support, yeah.
 
-**Justin:** Runtime, like figuring out. How to render things across many different platforms, another hard challenge. Um, and I'm super interested to ask more about this, but I kind of wanted to start talking a little bit about the editor. 
+**Justin:** Runtime, like figuring out. How to render things across many different platforms, another hard challenge. Um, and I'm super interested to ask more about this, but I kind of wanted to start talking a little bit about the editor.
 
 
 #### [00:19:42] State Machines: A Designer's Tool
@@ -257,9 +257,9 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Guido:** And be able to swap out data models, so you can, for example, test like, Oh, what does my app look like if it's in Italian versus Turkish, you know, or, uh, Japanese, um, but then also be able to bind properties to one another and do, it unlocks a bunch of really interesting stuff that, that leads up to, um, to our scripting feature that is going to be all tied into this, but.
 
-**Guido:** Yeah, uh, so there's a lot more to come, um, is what I'm saying here, but, but definitely I think the state machine has been kind of the biggest, like, I think helped people realize that we're trying to build something different, not, not just another design tool. 
+**Guido:** Yeah, uh, so there's a lot more to come, um, is what I'm saying here, but, but definitely I think the state machine has been kind of the biggest, like, I think helped people realize that we're trying to build something different, not, not just another design tool.
 
-**Justin:** That's, that's really awesome. 
+**Justin:** That's, that's really awesome.
 
 
 #### [00:29:18] Exploring the RIV File Format
@@ -270,7 +270,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** Usually it's like, there's a performance trade off. So as, as much as you're able, what is the, like, what are the decisions that y'all made to like, make it perform it? Like, what does the format look like? Or whatever you can describe there. I'm curious about
 
-**Justin:** that. I I think, yeah, my co founder would be able to describe this better. 
+**Justin:** that. I I think, yeah, my co founder would be able to describe this better.
 
 
 #### [00:30:30] Performance and Runtime Efficiency
@@ -291,7 +291,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Andrew:** And that, that's where really the performance comes from is the runtime and less the format. Um, I think the format is just really lightweight Yeah, comparing it to something like Lottie, they use a big old JSON file, so I'm sure just by having your own formats that's, that's binary, you can probably get a bunch of savings there. So you mentioned that, uh, the, the product is for more than just building like interactive graphics, like most people, when they hear that, I think they think, Oh, there's a hero image on my page.
 
-**Andrew:** It's maybe an animated character, but you guys have much larger visions for what that means. So like, do you want me to build my entire website, uh, on Rive or, or is it just like some parts? 
+**Andrew:** It's maybe an animated character, but you guys have much larger visions for what that means. So like, do you want me to build my entire website, uh, on Rive or, or is it just like some parts?
 
 **Guido:** The website, I think the website is a bit of a stretch today. We have some accessibility stuff that we need to figure out first. Um, you can, there are best practices for, you know, making an entire canvas, your website that you can follow today. And you'd, there'd be a lot of manual work that you'd have to do to, you know, make sure that it's all accessible.
 
@@ -322,11 +322,11 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Guido:** And our, our vision is a little different because we think. A format needs to become, you know, to become a new design format, you have to become ubiquitous. And the problems that are facing game developers are the same that are facing, um, app developers like Duolingo and, and are the same things that are facing, you know, car, car developers or people building graphics for TV.
 
-**Guido:** All software is affected by this problem of hard coding graphics. And, and so I think that it carries across all those, all those verticals. 
+**Guido:** All software is affected by this problem of hard coding graphics. And, and so I think that it carries across all those, all those verticals.
 
 **Justin:** The idea of animation on embedded devices is very interesting. So, uh, in a different life, I was working with the food network team and they had, uh, a TV app for like the Roku or something. Right. And the Roku devices have like very, very little, uh, like capacity. So have you had customers who are actually building graphics on some embedded
 
-**Justin:** platforms? 
+**Justin:** platforms?
 
 **Guido:** yep, yep, we, we have, um, I think one we can share is, I mean, Google has been one of the earliest adopters arrived from like 2019 when it was still the first version we and I built, um, before it was this, the kind of the new version. Um, and I think they, they ship on, you know, Google assistant ships on. Uh, very, you know, tiny device, like, like the bedside devices and stuff like that.
 
@@ -350,7 +350,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Guido:** They can just load a new Rive file and provided those events and inputs and text rounds have all stayed the same. Um, they've empowered the designer to just build a whole new layout and a whole new UI that they can, you know, A, B test and stuff like that. So, yeah, the, the, the kind of cop out answer is that it depends, you know, and then there's people doing both.
 
-**Guido:** Uh, I think once we have data binding and layouts, which are coming, um, very soon, uh, you'll see a lot more like really crazy, different experiences that, that will be enabled by having, A design tool that lets you do that. 
+**Guido:** Uh, I think once we have data binding and layouts, which are coming, um, very soon, uh, you'll see a lot more like really crazy, different experiences that, that will be enabled by having, A design tool that lets you do that.
 
 **Andrew:** Yeah, it just clicked for me what you've been meaning with hard coded. Uh, cause I'm like, well, all UIs kind of hard, it's still hard coded, but like really the file format is what enables that you can dynamically serve the file format from a server. And that can tell your app what to render. So like that's where you can get that dynamic testing.
 
@@ -366,9 +366,9 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** And like, you know, kind of show their prowess, I guess. And, and I think that we're going to have more and more demand for. Interactive animated experiences going forward, and so I
 
-**Justin:** think y'all are 
+**Justin:** think y'all are
 
-**Justin:** in a great 
+**Justin:** in a great
 
 **Justin:** spot.
 
@@ -378,9 +378,9 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Guido:** And then with the exception of the ones you're talking about now, like there's these category defining products that are going all out to make sure that their pages really stand out. And. think that's part of, yeah, what we want to do with Rive is make sure that those tools are available to everyone.
 
-**Guido:** And it's not just a crack team of. You know, insane, WebGL developers that, that have a design team that can code a little bit that can help them get to that vision and instead empower designers to use the tools they're familiar with to to do that. 
+**Guido:** And it's not just a crack team of. You know, insane, WebGL developers that, that have a design team that can code a little bit that can help them get to that vision and instead empower designers to use the tools they're familiar with to to do that.
 
-**Justin:** Yeah, it's an awesome vision. 
+**Justin:** Yeah, it's an awesome vision.
 
 
 #### [00:46:04] Future Prospects and Scripting Capabilities
@@ -401,28 +401,28 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Guido:** So the fact that, like, I, I'm excited to, can't, can't share the game and the game companies that are working with Rive today, but, um, like, uh, you know, you can imagine someone having a really cool, You know, recognizable character in your game, and maybe a really cool menu built around that, but then also being able to load parts of that graphic or all the menu onto your website or onto a companion app, and empowering those type of, you know, scenarios that I think are going to be really exciting to see, like game websites that feel like the actual game menu from the game itself.
 
-**Guido:** Um, yeah, I think that's just exciting 
+**Guido:** Um, yeah, I think that's just exciting
 
-**Guido:** to think about. 
+**Guido:** to think about.
 
-**Andrew:** Yes. So many exciting things there. 
+**Andrew:** Yes. So many exciting things there.
 
 
 #### [00:49:02] Closing Thoughts
 
 **Andrew:** Like if you guys nailed that accessibility feature, I think that's going to like explode the use cases because like in the web development community, it comes up a lot that it's like, oh, I could just use canvas and my life would be a lot easier. And then the next question is, what about accessibility?
 
-**Andrew:** So if you bring with that and scripting, it seems like such a fun, exciting platform to me, like just through this conversation, I really want to go learn, uh, the tool myself now. Cause it just feels, feels like before this conversation, I was excited about it, but now I'm really excited. 
+**Andrew:** So if you bring with that and scripting, it seems like such a fun, exciting platform to me, like just through this conversation, I really want to go learn, uh, the tool myself now. Cause it just feels, feels like before this conversation, I was excited about it, but now I'm really excited.
 
 **Guido:** Yeah, that, we always talk about that. Like, that was one of the things Flash did really well. You know, we started this conversation talking a bit about Flash and, like, how it really converted a lot of design and made designers into developers. I mean, I, I learned a lot of code thanks to Flash, and I think we'll see a lot more of that, um, and, And we'll see a lot, I think we'll see the developer audience, you know, is already really big and right.
 
-**Guido:** We have 40 percent of our users are developers. Um, and, and I think it's just going to explode even more when, when scripting becomes, um, yeah, a big part of that feature set. 
+**Guido:** We have 40 percent of our users are developers. Um, and, and I think it's just going to explode even more when, when scripting becomes, um, yeah, a big part of that feature set.
 
 **Justin:** It's very fitting to sort of end on Flash because I think my feeling here for a long time is that There's just never been a really great replacement for Flash. Like, Flash was a really interesting moment in time, and it had a ton of warts, and it had a ton of problems, but it was like, this incredible tool that enabled a whole generation of makers to like, just create these really rich, crazy, interactive experiences.
 
 **Justin:** And that, I think, is the sort of mantle that Rive is taking on. It's like the only tool that I've seen thus far as like, this is like. The thing that Flash wish it could have been, you know, it's like, so
 
-**Justin:** I'm really excited to see it develop. 
+**Justin:** I'm really excited to see it develop.
 
 **Guido:** that's a lot of big shoes to fill, but that's awesome. Yeah, yeah, definitely lots of, we have the power of hindsight and avoiding some of the mistakes they made with like the proprietary runtime and all that type of stuff. Um, and, and yeah, not, you know, Rive is, Rive plugin that puts the onus on every user to install it manually and things like that, that I think ultimately we get to benefit from being in the age of, you know, More modern web tooling and all that.
 
@@ -430,14 +430,14 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Guido:** You know, um, we, we didn't talk about, you know, some of the differences with our runtime model, but, you know, the, the format is open source. The, uh, The runtime is open source, the renderer is open source, the editor is really how we monetize. Um, but we've, we've scaled even that back a lot this year and made it, you know, we found that most of our revenue tends to come from, uh, teams collaborating and then upgrading to enterprise security and all those types of features that enterprises want.
 
-**Guido:** Um, and, uh, and, and that's really like, Our, our model is to make it as accessible and as free as possible for, for individual users to use it and to become champions and bring it to their workplace and their enterprises where, and we hope to capture, you know, some of the value and revenue, but, um, yeah, that's, that's really the, the whole for, for growth for 
+**Guido:** Um, and, uh, and, and that's really like, Our, our model is to make it as accessible and as free as possible for, for individual users to use it and to become champions and bring it to their workplace and their enterprises where, and we hope to capture, you know, some of the value and revenue, but, um, yeah, that's, that's really the, the whole for, for growth for
 
 **Guido:** Rive.
 
-**Andrew:** Sweet. Well, thanks for coming on. This was a lot of fun. 
+**Andrew:** Sweet. Well, thanks for coming on. This was a lot of fun.
 
-**Guido:** Awesome. 
+**Guido:** Awesome.
 
-**Guido:** both. 
+**Guido:** both.
 
-**Justin:** Yeah, thanks. This is, this is incredible. I'm super excited to see where y'all go. This is, it's an amazing tool. 
+**Justin:** Yeah, thanks. This is, this is incredible. I'm super excited to see where y'all go. This is, it's an amazing tool.

--- a/pages/episode/115.mdx
+++ b/pages/episode/115.mdx
@@ -1,5 +1,6 @@
 ---
 title: Guido Rosso - Rive, The Graphics Format of the Future
+sponsor: MUX
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Guido-Rosso---Rive--The-Graphics-Format-of-the-Future-e2onnfl
 youtube: https://www.youtube.com/watch?v=P1LsxSf3F8k
 tags: graphics, animation, design, tools, rive, flash, canvas, webgl, html5

--- a/pages/episode/116.mdx
+++ b/pages/episode/116.mdx
@@ -1,5 +1,6 @@
 ---
 title: Nathan Manceaux-Panot - Retcon - Rewriting Git History made Simple
+sponsor: MUX
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Nathan-Manceaux-Panot---Retcon---Rewriting-Git-History-made-Simple-e2p11e6
 youtube: https://www.youtube.com/watch?v=NeQGRrbMpJE
 tags: git, programming, software development, source control, source code, version control, git client, retcon, rewrite history, history, git history, git terminology, conflict resolution, undo, redo, virtual history

--- a/pages/episode/116.mdx
+++ b/pages/episode/116.mdx
@@ -1,9 +1,9 @@
 ---
 title: Nathan Manceaux-Panot - Retcon - Rewriting Git History made Simple
-sponsor: MUX
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Nathan-Manceaux-Panot---Retcon---Rewriting-Git-History-made-Simple-e2p11e6
 youtube: https://www.youtube.com/watch?v=NeQGRrbMpJE
 tags: git, programming, software development, source control, source code, version control, git client, retcon, rewrite history, history, git history, git terminology, conflict resolution, undo, redo, virtual history
+sponsor: MUX
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -68,7 +68,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Nathan:** Like the teacher is really good. Uh, and so that's how I learned iOS development. And a lot of that transfers to macOS development.
 
-**Andrew:** 
+**Andrew:**
 
 
 #### [00:02:36] Challenges of Building a Git Client
@@ -87,7 +87,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Nathan:** You're going to handle diffs and I don't know, commits and orders. And I mean, everything can happen at that point.
 
-**Justin:** So maybe let's let's back up a little bit retcon specifically. 
+**Justin:** So maybe let's let's back up a little bit retcon specifically.
 
 
 #### [00:04:52] What Makes Retcon Unique?
@@ -130,7 +130,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Andrew:** It can be a lot. With Mux's automatic cold storage feature, it makes it a bit cheaper. For each video that your platform has, it tracks whether or not it's being streamed. If it hasn't been streamed in a certain amount of time, it moves to colder and colder storage and saves you more and more money.
 
-**Andrew:** I think that's pretty cool. That is just among a host of other things that make shipping video with Mux a breeze. So if you want to learn more about Mux, head over to Mux. com to check them 
+**Andrew:** I think that's pretty cool. That is just among a host of other things that make shipping video with Mux a breeze. So if you want to learn more about Mux, head over to Mux. com to check them
 
 #### [00:11:22] Virtual History and Conflict Resolution
 
@@ -164,7 +164,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** Uh, so it's really interesting to hear that it'll like, pick up those actions and sort of like, you know, insert them in the correct place. Is there a point at which. You just have to throw away the virtual history. You're like, okay, you've done something and like, we're, we're down this track, but like, we just need to like abort and go back to like the current state of the repo or like unwind the virtual, the
 
-**Justin:** virtual history stack or something. 
+**Justin:** virtual history stack or something.
 
 **Nathan:** I I don't think so. I don't think so. I mean, anything, no, cause like you transform the virtual history and it always represents something. I mean, if you, if you. Like in the extreme, most extreme of cases, you'll get conflicts at every commit, right? You resolve one, and the next one's a conflict. You resolve all of these, in a way that makes sense, if you can.
 
@@ -196,7 +196,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Nathan:** And it's more about absolutes. You want to know what you want to get to, where you want to be. So. You know, in memory, what is stored is the virtual history, like the actual thing you want to happen. Um, and that moves the problem that doesn't remove it, that moves it. It means now the problem is having incorrect absolute thing at all times.
 
-**Nathan:** Um, uh, but that also means it can be handled differently. 
+**Nathan:** Um, uh, but that also means it can be handled differently.
 
 
 #### [00:23:14] Undo and Redo in Retcon
@@ -243,7 +243,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** and or other people's lives easier. Like, if you could make a change to get today, it is like, okay, well, if I did this, it would make things so much easier. Like, what would that be? And why would you want to do it?
 
-**Nathan:** that's a good question. I don't know that I have an answer for that. Um, I'm thinking because, you know, a lot of I don't know, Git is pretty tight, right? Like, the model is pretty solid. Um, you know, I'm going to avoid that. I'm going to, I'm going to evade that question and go slightly to the design side. 
+**Nathan:** that's a good question. I don't know that I have an answer for that. Um, I'm thinking because, you know, a lot of I don't know, Git is pretty tight, right? Like, the model is pretty solid. Um, you know, I'm going to avoid that. I'm going to, I'm going to evade that question and go slightly to the design side.
 
 
 #### [00:31:05] The Complexity of Git Terminology
@@ -278,7 +278,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Nathan:** There's one thing and okay. This is one thing that is changing retcon. Um, and that I haven't gotten a lot of feedback on some, I should ask for a feedback. Um, it's got to do with the stage, the way you stage things. So in, uh, usually in Git clients, when you want to create a new commit, you know, you're going to go and stage things.
 
-**Nathan:** So you've made changes, your working directory, it's got, it's dirty, right? It's got this uncommitted changes and you're going to stage some of them. Like, Oh, that file in this file, I want these to be containing the commit, but that third file doesn't come along. So you stage just what you want. It's at file level and it's also at line level within the 
+**Nathan:** So you've made changes, your working directory, it's got, it's dirty, right? It's got this uncommitted changes and you're going to stage some of them. Like, Oh, that file in this file, I want these to be containing the commit, but that third file doesn't come along. So you stage just what you want. It's at file level and it's also at line level within the
 
 **Nathan:** file
 
@@ -371,7 +371,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 #### [00:50:22] The Future of Source Control
 
-**Andrew:** So wrapping up here, we usually like to ask a future facing question. And for you, I want to ask you, what do you think the future of source control looks like? 
+**Andrew:** So wrapping up here, we usually like to ask a future facing question. And for you, I want to ask you, what do you think the future of source control looks like?
 
 **Nathan:** That's a good question. It's interesting, because Git is, is there, right? Git is, everyone uses Git, not everyone, like game developers don't, but It's just, it's like the default, there's a monoculture sort of monoculture of Git. And it's not a bad thing because Git is really good. Git is an open source, Git continues on evolving. Um, I don't know, right now it's hard to imagine anything replacing Git, but I guess that's always the case.
 
@@ -389,7 +389,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** I could, I could totally see Git just becoming the sort of infrastructure where the model is retained and the services are retained, but like, like what you're doing and like what a lot of other products are doing is like the UX just changes on top and how we interface would get just like fundamentally changes, but the things that are under the hood just kind of persist.
 
-**Nathan:** And we probably have a lot of examples of that in other areas, like the web and stuff like that, where the, the core state of as the compatibility, compatibility layer, but then yeah, higher level abstractions are built on top. That would be 
+**Nathan:** And we probably have a lot of examples of that in other areas, like the web and stuff like that, where the, the core state of as the compatibility, compatibility layer, but then yeah, higher level abstractions are built on top. That would be
 
 **Nathan:** cool to see.
 
@@ -399,7 +399,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** indeed.
 
-**Andrew:** Cool. 
+**Andrew:** Cool.
 
 
 #### [00:52:47] Wrapping Up and Final Thoughts
@@ -408,6 +408,6 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Nathan:** Thanks.
 
-**Justin:** Yeah, thanks Nathan. And you know, congrats on the launch. Uh, that's huge. Uh, the tool looks awesome. I'm excited to, to give it a try. Uh, yeah. And so for the listeners who want to give it a try, you can go to retcon. app. That's R E T C O N. app. Cool. And thanks for joining us. 
+**Justin:** Yeah, thanks Nathan. And you know, congrats on the launch. Uh, that's huge. Uh, the tool looks awesome. I'm excited to, to give it a try. Uh, yeah. And so for the listeners who want to give it a try, you can go to retcon. app. That's R E T C O N. app. Cool. And thanks for joining us.
 
-​ 
+​

--- a/pages/episode/117.mdx
+++ b/pages/episode/117.mdx
@@ -1,9 +1,9 @@
 ---
 title: Kris Rasmussen - Figma
-sponsor: MUX
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Kris-Rasmussen---Figma-e2pk89r
 youtube: https://www.youtube.com/watch?v=3TcYJafhIeo
 tags: figma, webgl, wasm, ai, design, development, programming, javascript, react, vue, angular, node, rust, rustlang, rust-lang, rust-lang
+sponsor: MUX
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -152,7 +152,7 @@ When building a video player, there's lots of things you have to worry about. Pl
 
 That's why Mux came out with a new thing called Player. Style. Player. Style is a front end component for playing back video. And then styling it however you want. It's super nice. It's feature packed. You can make the thing look like any player that you want, really. I can't see why you wouldn't want to start [00:14:00] with something like this. And that's coming from me, the person who actually built and maintained Descript's video player. So if you want to save yourself a bunch of time and add video to your platform super easily, I would over to mux.
 
-com right now and check them out. With that, let's get back to the 
+com right now and check them out. With that, let's get back to the
 
 
 #### [00:14:14] Challenges of Running Figma at Scale
@@ -183,7 +183,7 @@ Um, but also every single feature we build. You have to kind of reason about it 
 
 So those are the, the kind of like bespoke challenges. I think that we, uh, we run into at Figma that a lot of people don't always realize.
 
-**Justin:** Yeah, I can't, I can't imagine the sort of like scale and complexity of that. Uh, just like the rendering problems alone. It's like you just want to like render sort of like what someone's seeing. But, you know, as they, as they scroll, you want it to be performant, responsive. It's, it's a wild problem. 
+**Justin:** Yeah, I can't, I can't imagine the sort of like scale and complexity of that. Uh, just like the rendering problems alone. It's like you just want to like render sort of like what someone's seeing. But, you know, as they, as they scroll, you want it to be performant, responsive. It's, it's a wild problem.
 
 
 #### [00:18:39] Introducing Dev Mode: Simplifying Design Handoff
@@ -315,7 +315,7 @@ Like it's, it's kind of like, you know, at the end of the day, um, you can only 
 
 You don't want to have to keep telling people how to change things. Um, I think in the same way, you don't want to just keep telling this model, like, no, no, you don't, you didn't get what I said, I really meant this thing in the top right, or whatever. Um, so I think that, um, we're like really excited about exploring for our own use cases.
 
-How to marry the best of these new input modalities that the technology unlocks, like natural language, you know, maybe voice someday and whatnot with like existing, um, interfaces and direct manipulation. And in, you know, trying to give people the choice so that, you know, maybe when you're just kind of roughly trying to visualize someone else's idea, you can ask the tool to kind of help you get started, but do it in a way that is consistent with your brand and your identity and, you know, your existing code base.[00:37:00] 
+How to marry the best of these new input modalities that the technology unlocks, like natural language, you know, maybe voice someday and whatnot with like existing, um, interfaces and direct manipulation. And in, you know, trying to give people the choice so that, you know, maybe when you're just kind of roughly trying to visualize someone else's idea, you can ask the tool to kind of help you get started, but do it in a way that is consistent with your brand and your identity and, you know, your existing code base.[00:37:00]
 
 But then you still can just like, you know, grab the keyboard or grab the mouse and, you know, go click on the thing and like drag a color wheel and figure it out, um, and build up your own strong mental model. Um, so you can reason about it better for yourself rather than relying on some, some random model to do so with the context you give it.
 
@@ -383,7 +383,7 @@ And so, um, I think, I think, yeah, sometimes we get so fixated on like kind of 
 
 **Kris:** Yeah, that's a good question. Uh, we do it largely in the cloud. Um, although we, we are exploring like ways to run models locally too, where appropriate, but right now it's in the cloud.
 
-**Andrew:** For sure. 
+**Andrew:** For sure.
 
 
 #### [00:46:57] The Future of Figma: New Features and Innovations
@@ -404,7 +404,7 @@ And I think there's, there's a lot more that we're going to be doing and can be 
 
 **Kris:** Awesome. Thanks.
 
-**Andrew:** Sweet. 
+**Andrew:** Sweet.
 
 
 #### [00:48:46] Conclusion and Closing Remarks
@@ -415,4 +415,4 @@ And I think there's, there's a lot more that we're going to be doing and can be 
 
 **Justin:** Yeah. Thanks, Chris. Figma is, is huge. It's really changed our industry and it's a delight to use. And, uh, yeah, keep up
 
-**Kris:** Thank you. All right. 
+**Kris:** Thank you. All right.

--- a/pages/episode/117.mdx
+++ b/pages/episode/117.mdx
@@ -1,5 +1,6 @@
 ---
 title: Kris Rasmussen - Figma
+sponsor: MUX
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Kris-Rasmussen---Figma-e2pk89r
 youtube: https://www.youtube.com/watch?v=3TcYJafhIeo
 tags: figma, webgl, wasm, ai, design, development, programming, javascript, react, vue, angular, node, rust, rustlang, rust-lang, rust-lang

--- a/pages/episode/121.mdx
+++ b/pages/episode/121.mdx
@@ -3,6 +3,7 @@ title: Evan You - Vue, Vite, VoidZero and the Future of JavaScript Tooling
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Evan-You---Vue--Vite--VoidZero-and-the-Future-of-JavaScript-Tooling-e2qqbv4
 youtube: https://www.youtube.com/watch?v=Aqfgw9XUIRA
 tags: tooling, javascript, vue, vite, voidzero, evan you, technology, typescript, programming, coding, software engineering, build tools, javascript tooling
+sponsor: MUX
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/122.mdx
+++ b/pages/episode/122.mdx
@@ -1,9 +1,9 @@
 ---
 title: Dan Stepanov - NativeWind, NativeWind UI
-sponsor: MUX
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Dan-Stepanov---NativeWind--NativeWind-UI-e2r4fov
 youtube: https://www.youtube.com/watch?v=EVfjZgtZQuM
 tags: technology, programming, react, react native, native wind, native wind ui, tailwind css, tailwind ui, native, javascript, typescript, react native, css, html
+sponsor: MUX
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -62,7 +62,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Dan:** So for about 10 years, I have been, uh, primarily focused on mobile apps and I was sort of shoehorned into working on. React native back in 2015 and have kind of been here ever since through many, many iterations, but where, you know, the first eight years we'll call it was spent largely focused on, you know, applications and stuff, the last two, maybe a little more have been focused primarily on building developer tooling.
 
-**Andrew:** Cool. 
+**Andrew:** Cool.
 
 
 #### [00:01:41] Dan's Journey to NativeWind
@@ -109,7 +109,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Dan:** But for a lot of people, you know, your banks, your, your healthcare apps, it doesn't matter really. And it's important that they have the tooling to, to make things cross platform or whatever. And this is why I don't see things as like one tool versus another. I think we all have a role to play in that, that process.
 
-**Dan:** Yeah, and then you can just focus on your, your zone, right? Your, your fraction of the pie is like, we serve these people and by not trying to do more than that, we're going to be the best within this subcategory. 
+**Dan:** Yeah, and then you can just focus on your, your zone, right? Your, your fraction of the pie is like, we serve these people and by not trying to do more than that, we're going to be the best within this subcategory.
 
 **Andrew:** So would you say native win is in that second category where you like lean more into like the native feel or is it the opposite where you lean more into the universal feel?
 
@@ -124,21 +124,21 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 #### [00:10:53] Ad
 
-**Andrew:** We'd like to stop and thank our sponsor for the week. MCSE. If you haven't heard of mux, mux is an amazing platform That makes adding video to your product is easy. adding a few libraries to your code. You've ever had to add video to a product. You know, there's so many different pits of failure that you can fall into along the way. 
+**Andrew:** We'd like to stop and thank our sponsor for the week. MCSE. If you haven't heard of mux, mux is an amazing platform That makes adding video to your product is easy. adding a few libraries to your code. You've ever had to add video to a product. You know, there's so many different pits of failure that you can fall into along the way.
 
-**Andrew:** When it comes to video, you have to worry about every end of the experience. There's so many things to learn about and so many things to optimize and so many things that are going to stop you from shipping faster. So that's where monks comes in. They have an awesome set of API APIs and components that you can sprinkle throughout your code to add a seamless video playback experience. 
+**Andrew:** When it comes to video, you have to worry about every end of the experience. There's so many things to learn about and so many things to optimize and so many things that are going to stop you from shipping faster. So that's where monks comes in. They have an awesome set of API APIs and components that you can sprinkle throughout your code to add a seamless video playback experience.
 
-**Andrew:** They're a team of experts in the video field that know everything there is to know about playing video on the web And they'll have you shipping in no time. The thing I'd like to highlight this week is how many options they give you when it comes to streaming? They have three different levels. 
+**Andrew:** They're a team of experts in the video field that know everything there is to know about playing video on the web And they'll have you shipping in no time. The thing I'd like to highlight this week is how many options they give you when it comes to streaming? They have three different levels.
 
-**Andrew:** Basic plus in premium. And with the new premium one, you can serve the highest quality video to your customers. For a multitude of new use cases. 
+**Andrew:** Basic plus in premium. And with the new premium one, you can serve the highest quality video to your customers. For a multitude of new use cases.
 
-**Andrew:** you can stream things like, High-end sports events. And anything that needs that extra bit of quality. But they still have the rest of the range. If you don't want to pay as much all the time. 
+**Andrew:** you can stream things like, High-end sports events. And anything that needs that extra bit of quality. But they still have the rest of the range. If you don't want to pay as much all the time.
 
-**Andrew:** So, if you want to learn more about mux and add video to your product faster than you ever thought before. Head over to muck stock. Dot com. 
+**Andrew:** So, if you want to learn more about mux and add video to your product faster than you ever thought before. Head over to muck stock. Dot com.
 
 **Andrew:** And with that, let's get back to the episode.
 
-**Dan:** 
+**Dan:**
 
 
 #### [00:12:18] Challenges and Innovations in NativeWind
@@ -159,13 +159,13 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** so, uh, the things you were talking about adding there were like CSS features, right? Because when you're using tailwind, you have like hovers and all of these other things. So you're talking about like what things you actually choose to implement because those don't exist in react
 
-**Andrew:** native, right? 
+**Andrew:** native, right?
 
 **Dan:** Exactly. And there's a lot of assumption on like, what does that mean? What does hover mean on native? Right? Um, further, we just included animations and trend, uh, like transitions with version four. Um, What does that look like? Like, how do people interact with animations and what are their expectations?
 
 **Dan:** What does it look like when they chain animations together and what are their expectations there? Are they passing by value? Are they passing by percentage? You know, uh, all of these different kinds of things. It's, it's a perpetual iterative process to try to understand more of the behavioral aspect of what is, what is the experience people are looking for.
 
-**Dan:** And then we double back and we make it performant, right? We make it like something you really want to use. And ideally really can't operate without, then we make it performant. You know, that's, that's kind of our, our approach. 
+**Dan:** And then we double back and we make it performant, right? We make it like something you really want to use. And ideally really can't operate without, then we make it performant. You know, that's, that's kind of our, our approach.
 
 
 #### [00:15:58] Performance and Optimization in NativeWind
@@ -180,7 +180,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Dan:** There's larger changes to be had. We're currently working on a more like pure native wind variant, uh, that we see as like the first step in a much more performance library, we have a lot of plans in the coming months that now that we have version four out. We can take those risks, right? We, we have something that we can give people that's more stable that they can use so that we can really get more experimental.
 
-**Dan:** with that performance aspect. 
+**Dan:** with that performance aspect.
 
 **Andrew:** What is this pure version that you're talking about? How does that change things?
 
@@ -192,14 +192,14 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Dan:** Uh, the pure version is like. Let's introduce, let's, let's introduce a minified version of it so that we can intentionally then layer in the other stuff as necessary. And that way we can control better for any performance hits that you might incur while using it for your projects. performance in React Native inherently is a pretty weird thing.
 
-**Dan:** Cause it already, I mean, React Native by nature is already including a lot of stuff that you just don't need. Um, yeah, it's my journey in native wind has predominantly been one of learning more about bundlers. Um, I think any, any person who jumps into dev tooling is eventually just going to get to that layer and you have a decision to make of, are you wanting, you know, do you want to go deeper into the world of ASTs? You know, I don't know. I don't know what the answer is for that, you know, for me yet, but. It's increasingly becoming like 
+**Dan:** Cause it already, I mean, React Native by nature is already including a lot of stuff that you just don't need. Um, yeah, it's my journey in native wind has predominantly been one of learning more about bundlers. Um, I think any, any person who jumps into dev tooling is eventually just going to get to that layer and you have a decision to make of, are you wanting, you know, do you want to go deeper into the world of ASTs? You know, I don't know. I don't know what the answer is for that, you know, for me yet, but. It's increasingly becoming like
 
 **Dan:** the thing.
 
 
 #### [00:20:39] Supporting Different Bundlers
 
-**Andrew:** Have you guys had to like grapple with a bunch of different bundlers? Does NativeWin only like support Metro out of the box or something? 
+**Andrew:** Have you guys had to like grapple with a bunch of different bundlers? Does NativeWin only like support Metro out of the box or something?
 
 **Dan:** Yeah. Yeah. So I get this question a lot, right? Like you have, right. Cause right now everyone's like, you know, there's all these different bundlers and stuff and you got V and repack and Metro and stuff. And Metro is its own whole thing. Um, that has sort of both the human level, you know, challenge, and then there's like technical challenges.
 
@@ -217,7 +217,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Andrew:** Yeah. It seems like native is a hard platform to develop for. Like I, myself, I'm a web developer, but anytime I've tried to dip my toe in some iOS development, like the docs are just like inscrutable. Like they're everywhere. It seems like there's not enough people tell me to go like watch videos from like keynotes.
 
-**Andrew:** And it just like it, like the OS is a black box and it shouldn't be, and it kind of baffles me. 
+**Andrew:** And it just like it, like the OS is a black box and it shouldn't be, and it kind of baffles me.
 
 **Dan:** I struggle with this so much because people will ask me, especially cause I I've had experience. My initial experience with mobile development is native iOS, like objective C and Swift. People ask me like, Oh, what is the best way to build apps? You know? And what do you think of react native? And I'm like, it's shit.
 
@@ -235,7 +235,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Dan:** a different mode of thinking than React Native provides out of the box. And, um, to sort of circle then back around to, I think, Justin, something you were asking. Is I think one of the biggest challenges of react native in contrast, like if you came into mobile development through react native.
 
-**Dan:** I kind of feel bad for you because it doesn't react native. That is provide a straightforward path by which to understand how to even create that native feeling experience. 
+**Dan:** I kind of feel bad for you because it doesn't react native. That is provide a straightforward path by which to understand how to even create that native feeling experience.
 
 **Justin:** Right. And I think that's so much of what is lacking and a lot of the tools that I then build. Small or large are just in an effort to bridge that gap, T
 
@@ -270,7 +270,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** Was it like, what was the motivation? And yeah, how's it going?
 
-**Dan:** Yeah. 
+**Dan:** Yeah.
 
 
 #### [00:32:06] Pricing Models and Open Source Dilemmas
@@ -293,7 +293,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Dan:** Whatever they were able to get into Spyro 1 is what they're going to get in, and that's going to be the experience, and that's what people are going to remember. Years down the line, um, or like Halo and Halo two, you know, those were not perfect, but iconic, memorable experiences. And I want to try to hang on to that as much as I can.
 
-**Dan:** Like I, I admire that one time purchase. I've introduced recurring subscriptions. I still don't know how I feel about that. You know, I'm kind of curious how you guys think about this, you know, like I'm, I'm very curious to hear what your perception is of all these different things, but it's something that I think about a lot. 
+**Dan:** Like I, I admire that one time purchase. I've introduced recurring subscriptions. I still don't know how I feel about that. You know, I'm kind of curious how you guys think about this, you know, like I'm, I'm very curious to hear what your perception is of all these different things, but it's something that I think about a lot.
 
 **Justin:** It is a conversation we tend to have very frequently on the podcast. It's like, you're doing a thing, most of your work is maybe open source, how do you Make it sustainable. Like, what do you do? Um, so Adam Watham and team have, you know, made Telwind a phenomenal success, um, by, you know, offering layers of stuff, it's, you know, very similar models, like basically give away Telwind for free and then build a lot of like high quality resources on top of that, and, you know, that's what we do.
 
@@ -325,11 +325,11 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Dan:** And then we'll launch. And then this'll, no, no, it won't. Cause if it hasn't popped off in the last six to 12 months, it's absolutely not going to pop off in the next month or two. Um, but marketing is hard and that's, that's really what I'm faced with right now is like, as an engineer, how do you marketing is not, uh, as what do you call it, trackable or quantifiable as engineering time is.
 
-**Dan:** And I can definitely see how an engine, you know, someone coming from that background might get very frustrated with, with, 
+**Dan:** And I can definitely see how an engine, you know, someone coming from that background might get very frustrated with, with,
 
-**Dan:** that dynamic, 
+**Dan:** that dynamic,
 
-**Andrew:** And as engineers, we love fast feedback loops. Marketing is the opposite. It's like you throw some stuff against the wall, some stuff might stick. It probably wasn't because of you and you have to somehow use that information and go forward and like market a product. I I've failed at it many a time. 
+**Andrew:** And as engineers, we love fast feedback loops. Marketing is the opposite. It's like you throw some stuff against the wall, some stuff might stick. It probably wasn't because of you and you have to somehow use that information and go forward and like market a product. I I've failed at it many a time.
 
 **Dan:** I still, I mean, like today we had that video launch with Simon, right. And, uh, Simon Grimm is who I'm talking about. He does great videos on YouTube. Um, he, he made this video and I woke up today and I, you know, I got a hand, we got a handful of orders for native wind UI, and I'm still just so thankful for every single order that comes through.
 
@@ -337,9 +337,9 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Dan:** But I think we got a long way to go before then. And there's maybe some aspect of the formula that we could improve upon, but you know, I'm learning just like everybody else is I'm, I'm curious to see what happens between expo router and native wind, uh, what they offer there. And ultimately I just want, I want the experience of building react native applications to be not easy, but straightforward, I'm fine with painful.
 
-**Dan:** If it means that, you know, this framework is allowing me to do the wrong thing, but it's making it painful to do it, you know, and it'll make it like easy to do the right thing. 
+**Dan:** If it means that, you know, this framework is allowing me to do the wrong thing, but it's making it painful to do it, you know, and it'll make it like easy to do the right thing.
 
-**Justin:** So, maybe on that note, uh, as we wrap up, um, we, we always like to ask a, a future facing question, and I think that your lead in here is like perfect. 
+**Justin:** So, maybe on that note, uh, as we wrap up, um, we, we always like to ask a, a future facing question, and I think that your lead in here is like perfect.
 
 
 #### [00:44:50] Future of React Native and Expo
@@ -356,23 +356,23 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Dan:** It means so much. And, I would like these, what are currently challenging things to become a lot easier, or at least more straightforward so that people can focus on building meaningful, great applications without having to spend 80 percent of their time focused on how It would look native to its platform.
 
-**Dan:** And so what that's going to look like, very hard to say. I think from the expo side of things, we are going to see expo become a hosting service. They're going to start to host the ability to utilize react server components is going to, it's, it necessitates. a hosting platform alongside it. And so you're going to start to see native development, development overall shift to a different kind of dynamic. And there's not going to be nearly as many questions as there are now. I think it'll get more opinionated and there'll just be a lot of different opinionated approaches to doing this. So where native wind UI or any of the other stuff I plan to build fits into that, I have absolutely no idea. Anybody's guess yours as good as mine, 
+**Dan:** And so what that's going to look like, very hard to say. I think from the expo side of things, we are going to see expo become a hosting service. They're going to start to host the ability to utilize react server components is going to, it's, it necessitates. a hosting platform alongside it. And so you're going to start to see native development, development overall shift to a different kind of dynamic. And there's not going to be nearly as many questions as there are now. I think it'll get more opinionated and there'll just be a lot of different opinionated approaches to doing this. So where native wind UI or any of the other stuff I plan to build fits into that, I have absolutely no idea. Anybody's guess yours as good as mine,
 
 **Andrew:** Well, every time I talk to a react native developer, I'm always so excited to go try to build something. I am one of those web developers that looks over and goes, Oh yeah, I probably should have created a mobile app for that. Uh, so I'm very excited to try out what you got. I might try it the next time I try to build an app.
 
-**Andrew:** Happy to hook you up with a license. Both of you, if you'd like, uh, it's, uh, always looking for the 
+**Andrew:** Happy to hook you up with a license. Both of you, if you'd like, uh, it's, uh, always looking for the
 
-**Dan:** feedback. 
+**Dan:** feedback.
 
-**Andrew:** sweet. 
+**Andrew:** sweet.
 
 
 #### [00:48:48] Conclusion and Final Thoughts
 
 **Andrew:** Well, that wraps it up for our questions, Dan. Thanks for coming on. This is a really fun, interesting conversation diving into the depths of react native. So thanks again for coming on.
 
-**Justin:** Thanks, Dan. 
+**Justin:** Thanks, Dan.
 
-**Dan:** yeah, thanks for having me. 
+**Dan:** yeah, thanks for having me.
 
-​ 
+​

--- a/pages/episode/122.mdx
+++ b/pages/episode/122.mdx
@@ -1,5 +1,6 @@
 ---
 title: Dan Stepanov - NativeWind, NativeWind UI
+sponsor: MUX
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Dan-Stepanov---NativeWind--NativeWind-UI-e2r4fov
 youtube: https://www.youtube.com/watch?v=EVfjZgtZQuM
 tags: technology, programming, react, react native, native wind, native wind ui, tailwind css, tailwind ui, native, javascript, typescript, react native, css, html

--- a/pages/episode/123.mdx
+++ b/pages/episode/123.mdx
@@ -1,9 +1,9 @@
 ---
 title: Anselm Eickhoff - Jazz Tools
-sponsor: MUX
 spotify: https://open.spotify.com/episode/3dN0oKrWiGjNunFo7sWAz5
 youtube: https://www.youtube.com/watch?v=E7UNbIf6oA4
 tags: typescript, frontend, backend, jazz, local first, crdts, collaborative editing, data structures, databases, security, permissions, open source, business model, future, garden computing
+sponsor: MUX
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -123,7 +123,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Andrew:** So if you want to add video to your product and you've been held up in the details, go check out Mux today. With that, let's get back to the episode.
 
-**Andrew:** 
+**Andrew:**
 
 
 #### [00:09:21] Using Jazz: A Developer's Perspective
@@ -211,7 +211,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** Yeah, that makes a lot of sense. There are definitely, like, usability trade offs in there, but it's nice to have the option to be, like, completely hands off, especially in, you can think of scenarios of Like health data, for example, it's like, you know, there, there's a lot of liability to having access to health data.
 
-**Justin:** So if you can say we have no access, that's a, that's a really nice property. 
+**Justin:** So if you can say we have no access, that's a, that's a really nice property.
 
 
 #### [00:21:15] Challenges and Future of Jazz
@@ -220,7 +220,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** If you change the schema of an app. That can cause a ton of problems. Um, this is like what I think of as like one of the hard, mostly unsolved problems in the space. But I'm curious, like how you think about that? How do you think about schema changes and, uh, how that impacts, uh, like synced data over
 
-**Justin:** jazz? 
+**Justin:** jazz?
 
 **Anselm:** Yeah. I mean, as, as any local first framework developer will tell you like, yes, that's literally the hardest part of local first. And even to complete newcomers to local first, the way I sell it to them is like, look, it makes all of these really hard things really easy, but there's one thing that's kind of cursed now, which is migrations.
 
@@ -246,7 +246,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Anselm:** Um, the fun thing is we can just, uh, pull that into jazz as well. Clients and, or server workers could collaboratively maintain the index and the index gets synced as an object, just like everything else. So you get some really fun properties there. And, and over time, I want jazz to be more and more what looks like.
 
-**Anselm:** Okay. A distributed database that's kind of exploded into his part that does everything you need. 
+**Anselm:** Okay. A distributed database that's kind of exploded into his part that does everything you need.
 
 
 #### [00:25:40] Building Blocks of Jazz: A New Approach to Databases
@@ -255,9 +255,9 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Anselm:** And then you kind of assemble those into what, what you need for your app. And that's probably how like search indices will feel like in, in jazz. Um, Obviously part of that these days is also being able to do vector search. So we're like, um, what is every feature that people need from a database? Uh, and similar systems like blob storage nowadays.
 
-**Anselm:** And how can we make that work with the co values so far, the indication seems to be that surprisingly, you can just do all of it with jazz. And, and I feel like philosophically, there's a good reason for it because. The way I started seeing traditional stacks is they're just a very manual way of creating shared state for like structured and unstructured data between users and devices that just follows this established pattern of like, you have a backend, you have a database and you have clients, but there's kind of no. 
+**Anselm:** And how can we make that work with the co values so far, the indication seems to be that surprisingly, you can just do all of it with jazz. And, and I feel like philosophically, there's a good reason for it because. The way I started seeing traditional stacks is they're just a very manual way of creating shared state for like structured and unstructured data between users and devices that just follows this established pattern of like, you have a backend, you have a database and you have clients, but there's kind of no.
 
-**Anselm:** fundamental reason for why it should be structured like that. And if you turn the problem around and you're like, what's an abstraction for sharing state and, and making sync your main way to do that, suddenly everything that you need can fit into that model. So that's, that's what we're trying to do with jazz and, and, um, not just like theoretically, but including all the batteries and pragmatic like bindings You might need to actually get your app off the ground. 
+**Anselm:** fundamental reason for why it should be structured like that. And if you turn the problem around and you're like, what's an abstraction for sharing state and, and making sync your main way to do that, suddenly everything that you need can fit into that model. So that's, that's what we're trying to do with jazz and, and, um, not just like theoretically, but including all the batteries and pragmatic like bindings You might need to actually get your app off the ground.
 
 **Andrew:** That's, that's so cool you can find solutions like that where it's like you just have this encrypted file store that's automatically synced. I can do a whole lot for you.
 
@@ -276,7 +276,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Anselm:** Um, You could build that by hand right now, and we would be very happy to help you too. Just so far, we found that the people who, who try out jazz and adopt jazz, there's some, they're building something completely new where they can really do everything with jazz. And then obviously we have features to catch up with there in terms of unblocking different kinds of apps.
 
-**Anselm:** The other thing is, um, and I want to be really precise here because Developers are very keen to optimize and, and this is usually the part that sounds scariest to them, but jazz does keep the full edit history of everything you ever do to a co value. Um, 
+**Anselm:** The other thing is, um, and I want to be really precise here because Developers are very keen to optimize and, and this is usually the part that sounds scariest to them, but jazz does keep the full edit history of everything you ever do to a co value. Um,
 
 **Anselm:** the performance limit of that is way higher than you think it is.
 
@@ -292,7 +292,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Anselm:** For this user one time, they might not even ever come back, but that's very, a very different usage pattern from what you would expect from a typical local first apps where you have small teams that interact mostly with the same data again and again, that they keep locally. And we had to stretch jazz a little bit, but it only took us a week to basically optimize it for that use case.
 
-**Anselm:** And that's, that's the approach we will take. And. That's only possible because of what I briefly mentioned earlier, that jazz takes the default route of granularly loading data and not making 
+**Anselm:** And that's, that's the approach we will take. And. That's only possible because of what I briefly mentioned earlier, that jazz takes the default route of granularly loading data and not making
 
 **Anselm:** you define ahead of time as a developer, what is like a box of content that we can load as a unit, like, um, with a lot of other frameworks, it's either, um, database per client or organization.
 
@@ -310,11 +310,11 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Anselm:** And maybe you want to sync that to other devices. You now have the option to do that. And jazz is actually funnily enough more convenient to use than good old local state that's not even synced.
 
-**Andrew:** That's a really, that's a really fascinating, uh, concept, especially I'm thinking about, like, historical, like, uses data. It's like, suddenly you get, like, these analytics, uh, use cases falling out. 
+**Andrew:** That's a really, that's a really fascinating, uh, concept, especially I'm thinking about, like, historical, like, uses data. It's like, suddenly you get, like, these analytics, uh, use cases falling out.
 
 **Anselm:** Sorry. One more point as well, because you framed it as global state. One slogan that I really like is that the problem with global state is actually that it's not global enough and we're making it even more global.
 
-**Justin:** nice. 
+**Justin:** nice.
 
 
 #### [00:34:41] Open Source and Business Model of Jazz
@@ -325,7 +325,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Anselm:** Yeah, so I'll start by just kind of precisely describing the current situation where like, yes, the framework and all of the packages around it are open source. There's an open source version of the sync and storage server you can run yourself. And, um, again, just to be completely transparent here, It's easy to run that on a single server.
 
-**Anselm:** If you want to scale it across multiple servers, we don't really like help you with that much, but if you're smart, you can totally figure it out and you can basically build a clone of, of jazz cloud. And that's very intentionally so. 
+**Anselm:** If you want to scale it across multiple servers, we don't really like help you with that much, but if you're smart, you can totally figure it out and you can basically build a clone of, of jazz cloud. And that's very intentionally so.
 
 **Anselm:** We're starting to build convenience features around that into the commercial hosted version of jazz cloud, which again is the sync and storage as a service where like you get a nice dashboard and you actually get these like weirdly precise, but anonymized analytics about what users are doing in your app without any extra instrumentation.
 
@@ -367,7 +367,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Anselm:** I think the biggest problem is, um, honestly just getting people to think in that way, even like adopting a completely new way of, of building things. That's, that's like always the hardest part, but I think in terms of like what happened over the last 20 years, which is roughly like my awareness as a programmer This is the most radical shift that I've seen.
 
-**Anselm:** It's like in the front end sense, it's, it's as big as Rails and react. Um, but in the backend sense, 
+**Anselm:** It's like in the front end sense, it's, it's as big as Rails and react. Um, but in the backend sense,
 
 **Anselm:** like we haven't really moved from the traditional model at all. It's still database client server. And we've gotten more advanced about like. Um, how we structure apps, how we orchestrate it. But it's been the same, like all the time.
 
@@ -385,7 +385,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Anselm:** You can suddenly make industries out of what used to be tiny niches of end users that weren't worth it. building anything for either in a commercial or just like effort sense. On the other hand, big companies, um, who need lots of people can now suddenly Be more modern again and move really quickly.
 
-**Anselm:** That's, that's what really, really excites me. And the upside of that is so huge, but it's still like such a challenge to, to get people to even consider something new. So that's, that's, I think that the main thing. 
+**Anselm:** That's, that's what really, really excites me. And the upside of that is so huge, but it's still like such a challenge to, to get people to even consider something new. So that's, that's, I think that the main thing.
 
 **Andrew:** Yeah, I, I see a lot of parallels here between React and Jazz, where it's like when React came out, it kind of shirked a lot of what front end was about N-V-C-M-V-C-C. Splitting JavaScript, uh, UI as a function of state, all of those things were super new. And I see jazz doing very similar things where it's like, okay, we have this backend.
 
@@ -397,7 +397,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Anselm:** Apps like that weird way like that. That's just so much work.
 
-**Andrew:** 
+**Andrew:**
 
 
 #### [00:46:06] Future of Jazz and Garden Computing
@@ -426,7 +426,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Andrew:** so many cool things to unpack in there. Uh, if, if you guys do like notion is such a good like product to target. Cause like linear is just like, Oh, we're good Jira. And everybody's like, Oh, of course. And like, I think notions almost in that same place of everybody's like, we like it, but it's just like so terrible sometimes cause it's so slow and jazz could probably make that good.
 
-**Andrew:** The AI part though. That that really kind of just slapped me because like, since you, since you have all of your state and UI in this one place, you're right. Like you could have AI opening menus for you, uh, just because it knows where all of all of the state is. So that's, that's super cool. 
+**Andrew:** The AI part though. That that really kind of just slapped me because like, since you, since you have all of your state and UI in this one place, you're right. Like you could have AI opening menus for you, uh, just because it knows where all of all of the state is. So that's, that's super cool.
 
 
 #### [00:51:09] Conclusion and Final Thoughts
@@ -435,6 +435,6 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Andrew:** Uh, thanks for coming on Ansem. this is, this was a amazing, uh, really, uh, interesting talk for me. I'm super excited to use jazz. I've been looking for some tool like this for a while. So thanks for coming on the podcast and talking about it.
 
-**Anselm:** Yeah, my absolute pleasure. Thanks for your great questions guys 
+**Anselm:** Yeah, my absolute pleasure. Thanks for your great questions guys
 
-**Justin:** Yeah, it is wonderful to have you and jazz is such an incredible framework. So yeah, looking forward to trying it out. 
+**Justin:** Yeah, it is wonderful to have you and jazz is such an incredible framework. So yeah, looking forward to trying it out.

--- a/pages/episode/123.mdx
+++ b/pages/episode/123.mdx
@@ -1,5 +1,6 @@
 ---
 title: Anselm Eickhoff - Jazz Tools
+sponsor: MUX
 spotify: https://open.spotify.com/episode/3dN0oKrWiGjNunFo7sWAz5
 youtube: https://www.youtube.com/watch?v=E7UNbIf6oA4
 tags: typescript, frontend, backend, jazz, local first, crdts, collaborative editing, data structures, databases, security, permissions, open source, business model, future, garden computing

--- a/pages/episode/124.mdx
+++ b/pages/episode/124.mdx
@@ -1,9 +1,9 @@
 ---
 title: Matt Perry - (Framer) Motion - The Evolution of Animation Libraries
-sponsor: MUX
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Matt-Perry---Framer-Motion---The-Evolution-of-Animation-Libraries-e2s2kr4
 youtube: https://www.youtube.com/watch?v=Xlo5VeRJihs
 tags: technology, software, coding, CSS, javascript, animation, html
+sponsor: MUX
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -103,12 +103,12 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Matt:** They have to know it or that they're scared of it. Like it doesn't matter. You don't need, no one, you don't, no one needs motion values. Like 5 percent of the people need motion values. And those 5%, the stuff they do with it is, is incredible. so yeah, I, I haven't figured out the messaging and that's something I'd like to take a run at again, now that the docs are mine and it's, it's, it's more in my, uh, taking it motion independent, um, it's now more, um, My interests are aligned with making this as easy to use as possible.
 
-**Matt:** Well, let's talk about that a little bit. 
+**Matt:** Well, let's talk about that a little bit.
 
 
 #### [00:07:03] The Birth of Framer Motion
 
-**Justin:** So, you had created Pop Motion, what, it was like over six years ago? 
+**Justin:** So, you had created Pop Motion, what, it was like over six years ago?
 
 **Matt:** it's around that, yeah. I think it came out a little less, but I definitely joined Framer six years ago, and I made Pose not long before that, and it kind of carried straight through.
 
@@ -149,11 +149,11 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Andrew:** We'd like to stop and thank our sponsor for the week. Mux.
 
-**Andrew:** If you've ever tried to integrate video into your product, you know that it's no easy feat. And if you're building something complex that needs uploads, hosting and playback. It gets even harder. So that's where max comes in. Mucks is an all-in-one platform for helping you get video into your product and make it not a hassle at all. This week, I actually used monks. They have that open source project called player.style. It's a very easy to drop in component that will help you render a video player like with a bunch of different themes. They have Halloween themes. They have YouTube themes, Vimeo themes. You can make your video player look however you want, and not really even have to do anything at all. 
+**Andrew:** If you've ever tried to integrate video into your product, you know that it's no easy feat. And if you're building something complex that needs uploads, hosting and playback. It gets even harder. So that's where max comes in. Mucks is an all-in-one platform for helping you get video into your product and make it not a hassle at all. This week, I actually used monks. They have that open source project called player.style. It's a very easy to drop in component that will help you render a video player like with a bunch of different themes. They have Halloween themes. They have YouTube themes, Vimeo themes. You can make your video player look however you want, and not really even have to do anything at all.
 
 **Andrew:** All I had to do was install a react package, wrap it around the. Video element and I'm off to the races. I didn't even use max's platform. That's how good of a tool it is. But if you want to discover how good of a tool mux is for the entire video pipeline. I highly suggest you go over to mucks.com to check them out. And with that, let's get back to the episode.
 
-**Andrew:** So, uh, let's like kind of dig more into the library itself now. 
+**Andrew:** So, uh, let's like kind of dig more into the library itself now.
 
 
 #### [00:14:30] Technical Insights into Animation Performance
@@ -174,7 +174,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Andrew:** That'd be very cool to see from a framer or from
 
-**Andrew:** motion. 
+**Andrew:** motion.
 
 **Matt:** yeah, yeah, thanks, No, that's not, I, I really love that idea, because, I mean, it could happen at runtime. It could happen as a ESLint. I, I'm, I really delved into writing my own ESLint rules, but, um, that might be interesting as well. Um, it's funny because like, it's, it's hard to go. So this is, this is my problem with going, um, hard and fast on rules.
 
@@ -212,7 +212,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Justin:** at least it's nice to see the browsers improve.
 
-**Matt:** yeah, 100%, yeah, like intersectional observers is like a massive one. Um, in terms of like triggering, scroll triggering animation, how about having to, uh, uh, poll the scroll, um, every frame. or set up an event or something. 
+**Matt:** yeah, 100%, yeah, like intersectional observers is like a massive one. Um, in terms of like triggering, scroll triggering animation, how about having to, uh, uh, poll the scroll, um, every frame. or set up an event or something.
 
 **Matt:** And then you have like CSS properties, like, uh, transform, for example, which would, um, you, and you should never have to know anything about this. So it's, it's funny when you run into these things, in every browser, it used to be that if you animated like a transform X a hundred pixels, that would be accelerated, but if you animated a hundred percent, That wouldn't be accelerated because that relied on knowledge of the size of the, Of the element.
 
@@ -224,18 +224,18 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Matt:** Um, and that was kind of meant to be like the JQuery of, of WAPI in a sense. Um, so I'd, I'd have an option like you can, you know, allow WebKit acceleration Safari or allow WebKit acceleration default false because there's so many bugs that I was running into. Luckily, most of those gone away now, and they would have this little snippet that was like playback rate equals 1.
 
-**Matt:** 0, but you do these things you'd never notice or run into them. I think a lot of, I think a lot of performance worries are kind of once I overblown, I just. I think that definitely you need to, you need to profile and you need to test on different devices. I think that always 
+**Matt:** 0, but you do these things you'd never notice or run into them. I think a lot of, I think a lot of performance worries are kind of once I overblown, I just. I think that definitely you need to, you need to profile and you need to test on different devices. I think that always
 
-**Matt:** comes down to that. 
+**Matt:** comes down to that.
 
-**Andrew:** Cool. 
+**Andrew:** Cool.
 
 
 #### [00:24:48] Exploring Motion One and Future Directions
 
 **Andrew:** So you've mentioned it a few times now, uh, but you had this third project that came out, uh, I think a year or two ago when, uh, the web animation API started to gain traction, what you've been calling WAPI. Uh, so when I saw that come out, I was like, Oh, we, we, there is no more frame or motion anymore.
 
-**Andrew:** We can just use the browser, but that didn't seem to quite be the case. So what, what was the goal with motion one? 
+**Andrew:** We can just use the browser, but that didn't seem to quite be the case. So what, what was the goal with motion one?
 
 **Matt:** Yeah, Motion1 was like an experiment essentially. So both of the times I've ended up writing these animation libraries, I wanted to write a book. So it started with PopMotion. I was trying to write a book about UI animation and I ended up just writing the library. Likewise with Motion1, I think I wanted to write about browser APIs and stuff.
 
@@ -255,13 +255,13 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Matt:** And then they got improved in frame emotion, but never really made it back to motion one. So that's why motion now I'm re sort of launching the JavaScript API, the vanilla API. And it's now got all of those innovations that made it to frame emotion, but never made it to motion one. Um, but yeah, that's, that's basically what it was.
 
-**Matt:** It was an experiment that, that. went too far and, uh, I, I really enjoyed making it, but I just don't think it was a healthy, like, I'm not getting any younger. I don't, I don't need to do that. 
+**Matt:** It was an experiment that, that. went too far and, uh, I, I really enjoyed making it, but I just don't think it was a healthy, like, I'm not getting any younger. I don't, I don't need to do that.
 
 **Justin:** It'll be interesting to dig into in our next topic. Cause it does sound like you're going to go hard mode here, but before that, um, taking a library like frame of motion, which is like mostly react centric and you talked about doing a lot of more sort of vanilla stuff and motion one, and then. You know, rolling this all up together to release a library that will be not just react centric, have a good first class react experience, but like be more general usable.
 
 **Justin:** That's a really hard design problem because like how you think about animations and react is very different than how you think about animations and a lot of other, uh, frameworks and stuff. So how are you, like, what, what challenges have you faced? And, um, like how are you making these paradigms work together?
 
-**Matt:** I, um, luckily, uh, I, I don't want to say, I essentially, um, it almost sounds Machiavellian. I, I didn't plan for this in the sense that I knew this was going to happen, but I wrote everything with the consideration that at some point this might be broken out into internals. 
+**Matt:** I, um, luckily, uh, I, I don't want to say, I essentially, um, it almost sounds Machiavellian. I, I didn't plan for this in the sense that I knew this was going to happen, but I wrote everything with the consideration that at some point this might be broken out into internals.
 
 
 #### [00:29:50] Abstracting React from Frame of Motion
@@ -280,21 +280,21 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Matt:** So, oh, like if you, if you want uh, frame, frame, uh, motion for react, um, then you just is motion slash react. Uh, and I, when I start mixing, um, frameworks, that's going to be an interesting problem to solve. but I just like the aesthetics of it, which sounds shallow, but I actually think it changes, like, even the motion, like, you don't want a scoped package.
 
-**Matt:** That I just, I really feel like that's, maybe that's just a bias, but I feel like the aesthetics of importing from a scope package and things like that, they don't sit right with me. So I'm going to put an inordinate amount of work into making sure that you can just import everything from us from a 
+**Matt:** That I just, I really feel like that's, maybe that's just a bias, but I feel like the aesthetics of importing from a scope package and things like that, they don't sit right with me. So I'm going to put an inordinate amount of work into making sure that you can just import everything from us from a
 
-**Matt:** sub 
+**Matt:** sub
 
-**Matt:** entry point. 
+**Matt:** entry point.
 
-**Andrew:** That's going to be quite the challenge when it comes to types. I was thinking when you were talking like, Oh yeah, you just have two packages, but like optional peer dependencies for all the different frameworks. The move, that's going to be, it's gonna be a rough one. 
+**Andrew:** That's going to be quite the challenge when it comes to types. I was thinking when you were talking like, Oh yeah, you just have two packages, but like optional peer dependencies for all the different frameworks. The move, that's going to be, it's gonna be a rough one.
 
-**Matt:** Yeah. And it might be even impossible. I don't know yet, but, um, but that's the sort of thing that I'll at least give it a shot because I really, uh, value it and want that in my own 
+**Matt:** Yeah. And it might be even impossible. I don't know yet, but, um, but that's the sort of thing that I'll at least give it a shot because I really, uh, value it and want that in my own
 
-**Matt:** usage day to day 
+**Matt:** usage day to day
 
-**Matt:** you know? 
+**Matt:** you know?
 
-**Andrew:** Yeah. You've done a good job with the API. I was flipping through the docs today and the vanilla version. And I was like, Oh, this looks just like I would expect it to. A lot of the times when I see a vanilla API for some JavaScript library, I use The vanilla API is like. daunting, but this was like nice and approachable. 
+**Andrew:** Yeah. You've done a good job with the API. I was flipping through the docs today and the vanilla version. And I was like, Oh, this looks just like I would expect it to. A lot of the times when I see a vanilla API for some JavaScript library, I use The vanilla API is like. daunting, but this was like nice and approachable.
 
 **Matt:** Oh, thanks. Yeah. And, and it's nice that, so I haven't moved the certain things that I want to bring into the vanilla that will probably make it feel a little more daunting, like motion values. There's no reason why they'd live in react land. Um, likewise, a few things like gesture handlers. It's nice that there's only a few exports.
 
@@ -304,7 +304,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Matt:** That's the other nice thing. When I rewrite these things, um, I give it to the JavaScript, Uh, API, but before that gets published, I've, I'm going to rewrite how it's implemented and react using this API. Um, and if I hit any, you know, uh, boundaries or something, then that gives me a chance to make sure they're fixed essentially.
 
-**Matt:** Nice. 
+**Matt:** Nice.
 
 
 #### [00:34:40] Transitioning to Independent Development
@@ -335,13 +335,13 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Matt:** And so when you start feeling like if this was built today, we wouldn't have made it an open source animation library that I don't know, it always, it sort of spoke to me, like just that thought. I'm psyched. Yeah, I think we naturally arrived at this conclusion. Um, and like I say, they're the first and biggest sponsor, so they couldn't have been more supportive, really.
 
-**Matt:** and likewise, you know, it's going to continue powering the animations for all framework websites, uh, for, 
+**Matt:** and likewise, you know, it's going to continue powering the animations for all framework websites, uh, for,
 
-**Matt:** a while. 
+**Matt:** a while.
 
 **Andrew:** So when you break off and make your own company, though, there's a lot of things you got to think about. One of those being how you're going to fund it, uh, Framer being the first sponsor is great, but do you have plans for other things? Is it just going to be sponsorships? I saw like a big mention of courses on the page.
 
-**Andrew:** Do you plan on releasing a course? 
+**Andrew:** Do you plan on releasing a course?
 
 **Matt:** I'm not personally going to do a course, because to do it, like, so my problem is I want to do everything, very well. Um, and I know people who make courses very well. So I'm just getting like, I'm just going to forward people to their courses. I'm never going to do it better than these, these educators.
 
@@ -373,27 +373,27 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Matt:** but yeah, so, and this is all content that basically wouldn't exist if I didn't go into Pendant. Like, there was no reason for me to ever build this framework because it would take away from my content. Other responsibilities, essentially. Um, so again, it's the alignment of the, it's the alignment of mine, you know, my incentives to keep, to be able to keep it sustainable by making it better.
 
-**Matt:** That's the, that's the trick that I'm trying to 
+**Matt:** That's the, that's the trick that I'm trying to
 
-**Matt:** attempt, 
+**Matt:** attempt,
 
-**Matt:** I 
+**Matt:** I
 
-**Matt:** guess. 
+**Matt:** guess.
 
-**Andrew:** Yeah, I could imagine like a ShadCN like CLI where you like pop in like really complex animation like templates into a project and give the user a nice jumping off point. 
+**Andrew:** Yeah, I could imagine like a ShadCN like CLI where you like pop in like really complex animation like templates into a project and give the user a nice jumping off point.
 
 **Matt:** Yeah, exactly. That's exactly what I'm, I'm thinking. I was looking at their, like the way that you can, um, instill their components and I thought that's. That's actually exactly what I want, but I don't really know where to start, um, the end. I don't really know. No, I tell you what, no, but I do have, um, the custom cursor component almost ready.
 
 **Matt:** Um, and it's super nice. It's like it, so, you know, the Mac OS, uh, sorry, the, um, iPad cursor where it's like a ball, and then if you'd like, if you go over selectable text, it will like warp to match the size of the text. But likewise, you can just, you don't need to use that bit. You can like have custom content in there, or you can, um, have things follow the cursor.
 
-**Matt:** And, um, that's almost good to go. 
+**Matt:** And, um, that's almost good to go.
 
 **Andrew:** I actually have a component almost ready to ship, which is a custom cursor. Um, and that can do things like, it's a bit of an, um, uh, tablet started an iPad style cursor way or like.
 
 **Matt:** if you've got selectable text, like it will warp to match the font size, um, and, uh, you can put in custom content and, I want all these to work together with each other. So I'm just, it's just, it's a start, but what I'm hoping is that, of course, today it'd probably be only like diehard users that use it, but I want it to be in a position in a year's time where if you, you just want to use, like, there's so much there, so much value represented by that membership that you want, you know, that you want.
 
-**Matt:** It seems like a no brainer not to. Not to buy it. 
+**Matt:** It seems like a no brainer not to. Not to buy it.
 
 **Justin:** Yeah, I mean, this is a hard domain, uh, and even with a powerful tool, I think like, it's still hard. So there's like a lot of value to be added to the space. So I definitely think, you know, especially if you're able to keep it small, then yeah, I definitely think there's a lot of success in your future.
 
@@ -403,9 +403,9 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Matt:** Like. I did always work best like semi, like when I can concentrate on something and really go for it. Um, I think that's how I just tell operate best. And I'm not really looking for becoming like a business creator in the sense that I don't want the stuff that comes with the business. And I'm not really looking for like some ridiculous, like, I'm not looking for my empire.
 
-**Matt:** I'm just looking for like a, a way to work that. That is compatible with the way I think. That's, that's basically what I'm after here. So, I feel like because that's a reasonable goal, it should be reasonable to achieve. And whether or not it is, I don't know. But, um, that's the, that's what I'm 
+**Matt:** I'm just looking for like a, a way to work that. That is compatible with the way I think. That's, that's basically what I'm after here. So, I feel like because that's a reasonable goal, it should be reasonable to achieve. And whether or not it is, I don't know. But, um, that's the, that's what I'm
 
-**Matt:** after. 
+**Matt:** after.
 
 **Andrew:** W
 
@@ -440,23 +440,23 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Matt:** Um, I think there might be more of them, like, and that, because they're easier to perform, and that's, that's a nice, that's nice, and for them to feel like, like, using more spring animations, for instance, like, that's, you know, that's kind of where I want to see it go. I think things like, yeah, I think you see a lot of animations that, where, Apple are always very tasteful with doing things, this is exactly what I'm sort of saying, like, they have animations everywhere, but they're kind of always subtle, and they always feel nice, um, that really, Shit.
 
-**Matt:** And that I think is where we're heading like, yeah, essentially in terms of animation. I don't see, but maybe that's a lack of imagination. 
+**Matt:** And that I think is where we're heading like, yeah, essentially in terms of animation. I don't see, but maybe that's a lack of imagination.
 
-**Andrew:** A tasteful future for animations for all. It's definitely a fine line you have to walk. Uh, with designing animations and design in general of doing too much before you pull it back and do just enough. Uh, but that wraps it up for our 
+**Andrew:** A tasteful future for animations for all. It's definitely a fine line you have to walk. Uh, with designing animations and design in general of doing too much before you pull it back and do just enough. Uh, but that wraps it up for our
 
-**Andrew:** question. 
+**Andrew:** question.
 
 **Andrew:** So that's sort of exactly what I'm saying. Like, it's almost like as a society, we like we went too far. Um, flash as much as I love using it, but now it's been pulled back. It's like you do it personally like every artist sort of has that journey of like They go too far.
 
-**Matt:** They pull it back. I think the mega trend of design is is a bit Is 
+**Matt:** They pull it back. I think the mega trend of design is is a bit Is
 
-**Matt:** similar basically 
+**Matt:** similar basically
 
-**Andrew:** Cool. 
+**Andrew:** Cool.
 
 
 #### [00:53:45] Conclusion and Final Thoughts
 
-**Andrew:** Well, that wraps it up for our questions this week on this episode. Thanks for coming on. This was a really fun jaunt into all things animation. Uh, it's a pit of failure and motion makes it a pit of success. So thank you for coming on and talking about it. 
+**Andrew:** Well, that wraps it up for our questions this week on this episode. Thanks for coming on. This was a really fun jaunt into all things animation. Uh, it's a pit of failure and motion makes it a pit of success. So thank you for coming on and talking about it.
 
-**Matt:** Oh, thanks so much for having me like I've really enjoyed it. So yeah, Thanks 
+**Matt:** Oh, thanks so much for having me like I've really enjoyed it. So yeah, Thanks

--- a/pages/episode/124.mdx
+++ b/pages/episode/124.mdx
@@ -1,5 +1,6 @@
 ---
 title: Matt Perry - (Framer) Motion - The Evolution of Animation Libraries
+sponsor: MUX
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Matt-Perry---Framer-Motion---The-Evolution-of-Animation-Libraries-e2s2kr4
 youtube: https://www.youtube.com/watch?v=Xlo5VeRJihs
 tags: technology, software, coding, CSS, javascript, animation, html

--- a/pages/episode/125.mdx
+++ b/pages/episode/125.mdx
@@ -3,6 +3,7 @@ title: Rudy Fraser - BlackSky - Next Generation of Social Media
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Rudy-Fraser---BlackSky---Next-Generation-of-Social-Media-e2sc79h
 youtube: https://www.youtube.com/watch?v=qn7l-A6FQu8
 tags: social media, bluesky, bsky, rust, risky, content, moderation, programming, decentralized, protocol, community, blacksky, black sky, social, media, technology, software
+sponsor: MUX
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/137.mdx
+++ b/pages/episode/137.mdx
@@ -1,9 +1,9 @@
 ---
 title: Rodrigo Pombo - Code Hike and the Future of Content Authoring
-sponsor: WorkOS
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Rodrigo-Pombo---Code-Hike-and-the-Future-of-Content-Authoring-e316hga
 youtube: https://www.youtube.com/watch?v=wKfupjQSGns
 tags: code-hike, markdown, react, open-source, content-authoring, react-server-components, rsc, gfm, common mark, education, web, programming, coding
+sponsor: WorkOS
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -49,9 +49,9 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 {/* TAB: TRANSCRIPT */}
 
-**Rodrigo:** the limitation with markdown is that markdown is actually flat, 
+**Rodrigo:** the limitation with markdown is that markdown is actually flat,
 
-if you go to the RA syntax, trio of markdown is a list of block components. You have like headings, paragraph and you have the root and all, all these blog elements, you don't have nesting, 
+if you go to the RA syntax, trio of markdown is a list of block components. You have like headings, paragraph and you have the root and all, all these blog elements, you don't have nesting,
 
 #### [00:00:26] Introduction
 
@@ -66,7 +66,7 @@ So would you like to take a moment to tell our audience a little bit more about 
 
 **Rodrigo:** Yeah. Hi. So thank you for inviting me first. Nice to be here. Uh, so yeah, I'm Rodrigo Pombo. Most people call me Pombo. Uh, I've been doing software development for the last 16 years. I think I. Uh, I used to have a normal show in Argentina where I'm from until I quit in 2018. ~~Uh,~~ I took some kind of sabbatical time there, spent most of the time exploring, uh, developer tools, open source, mostly around the React ecosystem. Um, well fast, fast forward to now, uh, after all those years of. Exploration and several open source project. Uh, I think I found kind of my niche, uh, which roughly we can say is around UIs for, for technical content. Uh, so yeah, now I spend most of my time working on, on cold hike, as you mentioned, uh, and also doing related work to, to that.
 
-**Andrew:** Cool. 
+**Andrew:** Cool.
 
 
 #### [00:02:05] Introduction to Code Hike
@@ -125,15 +125,15 @@ And the idea is that the ecosystem provide those components for you. If, if, if 
 
 #### [00:09:13] Ad
 
-**Justin:** I'd like to thank the work OS team for sponsoring this week's episode. If you're a founder, an early stage engineer, you've probably been in that moment where you get your first enterprise customer through the door and they've got this long checklist of features that they need saml, SEIM, audit logs, rback, and you're just like, okay, well there goes r whole backlog. 
+**Justin:** I'd like to thank the work OS team for sponsoring this week's episode. If you're a founder, an early stage engineer, you've probably been in that moment where you get your first enterprise customer through the door and they've got this long checklist of features that they need saml, SEIM, audit logs, rback, and you're just like, okay, well there goes r whole backlog.
 
-And that's where Work OS comes in. It gives you a full suite of enterprise features. So single signon directory sync, user management, audit logs, fine grain auth. They even have, their own secure credential storage vault solution. And this is all in a developer first platform. And the product is really good. The SDKs are clean. The APIs are super consistent. The docs are delightful, like example driven. This just makes sense. 
+And that's where Work OS comes in. It gives you a full suite of enterprise features. So single signon directory sync, user management, audit logs, fine grain auth. They even have, their own secure credential storage vault solution. And this is all in a developer first platform. And the product is really good. The SDKs are clean. The APIs are super consistent. The docs are delightful, like example driven. This just makes sense.
 
 Everything fills designed for builders who just want to get work done and focus on their product. So instead of burning weeks, building all these things yourself and while your product languages give work less a try.
 
 That's work os.com. Again, thanks the Work OS team for supporting us.
 
-~~Um,~~ 
+~~Um,~~
 
 
 #### [00:10:29] Challenges and Innovations in Markdown
@@ -188,7 +188,7 @@ Code and like paste it in their code base or whatever, the comment's not gonna b
 
 **Justin:** ~~oh, yeah. Yeah. Uh, uh, so you use like, t uh, you're in some places you're using like, uh, uh, ~~cheeky two slash Right. Uh, the library that, um, kinda lets you do type annotations and
 
-stuff. 
+stuff.
 
 **Rodrigo:** No, no. We, we, we use similar, something similar. We, we like the same features, but, but it's not, you could choose, yeah.
 
@@ -204,7 +204,7 @@ And so we can benefit for, for, from that too. And that's all because of how, ho
 
 **Andrew:** Yeah, there are those few people in the community that are just like powerhouses. And it's like, how, how, how do you do it? Uh, with a lot of help. That's the answer. Um, so an interesting thing around cheeky or around your coat, hier, lighter, brighter, is it, or lighter.
 
-**Rodrigo:** Lighter. 
+**Rodrigo:** Lighter.
 
 
 #### [00:18:56] React Server Components and Code Hike
@@ -253,11 +253,11 @@ Or, you know, like whatever it may be. It's like, how do you sort of like. Uh, w
 
 **Rodrigo:** Yeah. So that's, that's a, like a real problem or even a real reason for, for not using cold hack, uh, because you are using like this non-standard orientation. Well, nothing is standard right now, but, um, portability is, is one of the reason that why Marham is so good. Um, that's why I. I mentioned, I tried that my priority was to add the minimal, uh, changes to margan or minimal annotations, uh, to achieve, uh, what, what I wanted, and also to make them easier, easy to search and replace in, in case needed.
 
-And also don't break any tooling that already use marm. So it's, it's not ideal, but. We, we took some, some measurements to, to, to avoid problems, but yeah. And yeah, Marlon is so popular that, yeah, it has so many flavors that it's just part of it. 
+And also don't break any tooling that already use marm. So it's, it's not ideal, but. We, we took some, some measurements to, to, to avoid problems, but yeah. And yeah, Marlon is so popular that, yeah, it has so many flavors that it's just part of it.
 
-**Andrew:** it. must 
+**Andrew:** it. must
 
-be hard. 
+be hard.
 
 **Rodrigo:** I consider that using a different extension too, but that will mean a lot of work too.
 
@@ -316,7 +316,7 @@ That's good. Not, not only call, um, in calling in both sides, but call and the 
 
 **Rodrigo:** Maybe, uh, we used to have in, in before B one. Um. Some code blocks that also run like the, like the demo with using something like, uh, web containers or, or sand pack, which is another thing that they can run, uh, things in the browser. And that was hard because of the integration mostly with sandag or uh, web containers.
 
-And, but I, I don't even have an example now with B one something I, I, I'm missing, but it's also because it's very like specific to a particular like thing you are doing. So it's hard to put genetic examples. 
+And, but I, I don't even have an example now with B one something I, I, I'm missing, but it's also because it's very like specific to a particular like thing you are doing. So it's hard to put genetic examples.
 
 **Justin:** So it sounds like, uh, code hike is pretty stable. You've kind of got like a lot of the things that you wanted to do with it done. You're sort of working with companies now to help integrate it. Uh, but it, it sort of begs the question as like, I'm, I'm sure you still have like a list of things that you really, really want to do and like, what does that, what does that look like for you?
 
@@ -328,9 +328,9 @@ Build the things. And so most of my to-do list is in, in that, uh, part of the, 
 
 And when you have like something, um, that isn't the shape you want, you can throw one error, but you could also use that schema for better, for better out authoring experience. Uh, right now, as I say, I use the outline of VS. Code a lot to navigate. But if I, if I already know the schema of the content. It could be much easier to, to navigate and to write the content and to edit it, but I'm realistic.
 
-I know that won't happen, uh, in the near future, but that, that is something that I, I would love to, to, 
+I know that won't happen, uh, in the near future, but that, that is something that I, I would love to, to,
 
-have. 
+have.
 
 **Andrew:** ~~Uh,~~ you, so you said you've been working with companies. Is there any company that shipped like a very code hike enhanced documentation experience yet?
 
@@ -344,7 +344,7 @@ uh, he's, uh, releasing a, an AI course and, and, and he's using the, a version 
 
 ~~but ~~
 
-**Andrew:** Yeah. Those are some great examples. 
+**Andrew:** Yeah. Those are some great examples.
 
 
 #### [00:40:10] Future of Content Authoring
@@ -359,7 +359,7 @@ Presentation, like the right level of richness in the, in the response. Uh, and 
 
 And, and then I take that description, I put it and put it in B zero, for example, or in vault, those UI generation tools. And it's not that good. Like I wish that will. I think in the future it will be much better and also this speed right now of doing all that is obviously slow, but I expect it to get better and I'm excited to for that, to get better because it will be amazing if it happens, right?
 
-Like to, to have something that gives you like that content in the best way possible to consume it. Amazing. 
+Like to, to have something that gives you like that content in the best way possible to consume it. Amazing.
 
 **Andrew:** Yeah, it, it, it would be an, an interesting world where you have a bunch of non-technical people writing, uh, markdown content and then just being like highlighting blocks and being like, now present this the best way you can to the user. And then like, getting like good bespoke experiences. That would be a quite the world to live in.
 
@@ -370,4 +370,4 @@ Like to, to have something that gives you like that content in the best way poss
 
 **Justin:** Yeah, it's great to have you and Code Hike is is excellent. I'm excited to see what you do with it in your future.
 
-**Rodrigo:** Thank you guys. Bye-bye. 
+**Rodrigo:** Thank you guys. Bye-bye.

--- a/pages/episode/137.mdx
+++ b/pages/episode/137.mdx
@@ -1,5 +1,6 @@
 ---
 title: Rodrigo Pombo - Code Hike and the Future of Content Authoring
+sponsor: WorkOS
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Rodrigo-Pombo---Code-Hike-and-the-Future-of-Content-Authoring-e316hga
 youtube: https://www.youtube.com/watch?v=wKfupjQSGns
 tags: code-hike, markdown, react, open-source, content-authoring, react-server-components, rsc, gfm, common mark, education, web, programming, coding

--- a/pages/episode/138.mdx
+++ b/pages/episode/138.mdx
@@ -1,5 +1,6 @@
 ---
 title: Sam Goodwin - Alchemy and the Next Generation of Infra as Code
+sponsor: WorkOS
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Sam-Goodwin---Alchemy-and-the-Next-Generation-of-Infra-as-Code-e31gcm4
 youtube: https://www.youtube.com/watch?v=babOa4shATk
 tags: infrastructure as code, alchemy, typescript, ai, cloudflare, aws, pulumi, terraform, cdk

--- a/pages/episode/138.mdx
+++ b/pages/episode/138.mdx
@@ -1,9 +1,9 @@
 ---
 title: Sam Goodwin - Alchemy and the Next Generation of Infra as Code
-sponsor: WorkOS
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Sam-Goodwin---Alchemy-and-the-Next-Generation-of-Infra-as-Code-e31gcm4
 youtube: https://www.youtube.com/watch?v=babOa4shATk
 tags: infrastructure as code, alchemy, typescript, ai, cloudflare, aws, pulumi, terraform, cdk
+sponsor: WorkOS
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -48,12 +48,12 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Sam:** Having spent 10 years in infrastructure as code to just be able to click my fingers and get a new resource.
 
-It's just magic. I'd like to see more people experience that and start thinking more about how well I can unbundle myself from all this mess and manage my own world. 
+It's just magic. I'd like to see more people experience that and start thinking more about how well I can unbundle myself from all this mess and manage my own world.
 
 
 #### [00:00:21] Introduction
 
-**Andrew:** Hello, welcome to Deb Tools fm. This is a podcast about developer tools and the people who make 'em. I'm Andrew, and this is my cohost Justin. 
+**Andrew:** Hello, welcome to Deb Tools fm. This is a podcast about developer tools and the people who make 'em. I'm Andrew, and this is my cohost Justin.
 
 **Justin:** Hey everyone, uh, we're really excited to have Sam Goodwin on the podcast with us. Uh, Sam, so you're working on this project called Alchemy. It's infrastructure is code. I am really excited to talk about it. It looks incredibly fascinating, uh, and in my opinion, I. There's just not enough new stuff happening in this space.
 
@@ -75,7 +75,7 @@ And I built a, I built a project called Punch Card, I think it was like 2019, wh
 
 Not many people know this. Alexa had a programming language called a CDL, so it was meant to be, this was before LLMs, but it was meant to be for programming conversations. So I got to build a compiler and a type checker and all that kind of thing. Ultimately, it didn't, didn't work out, but, uh, it was a great experience Nevertheless.
 
-Then finally, I, I did a brief stint on the CDK team in AWS, uh, but for things like time zones and, and difficulty, I, I ended up just leaving that and quit to start my own company. I think that was back in 2022. 
+Then finally, I, I did a brief stint on the CDK team in AWS, uh, but for things like time zones and, and difficulty, I, I ended up just leaving that and quit to start my own company. I think that was back in 2022.
 
 
 #### [00:03:55] The Birth of Alchemy
@@ -93,7 +93,7 @@ The problem to solve is at the root of this, it's not on top of infrastructure a
 
 **Andrew:** like what are some of those problems that you just alluded to in this space?
 
-**Sam:** Right in, in infrastructure as code like, uh, how, why it was invented or sort of what, what's wrong with it now? 
+**Sam:** Right in, in infrastructure as code like, uh, how, why it was invented or sort of what, what's wrong with it now?
 
 **Andrew:** What's wrong with it now?
 
@@ -140,7 +140,7 @@ And then find that gets you going for a while. And then you're like, okay, but I
 
 Like now I have three things to worry about that are effectively the same thing. Uh, so. By starting with CloudFlare, but the surface area is kind of small. Uh, it's a nice vertically integrated JavaScript ecosystem that you can make a lot of progress on quickly. Right. Just do workers, do workflows, do durable objects, and you know, you've got a lot of people happy by that point.
 
-Uh, yeah. 
+Uh, yeah.
 
 
 #### [00:11:04] The Role of AI in Infrastructure as Code
@@ -190,11 +190,11 @@ I just write a program that produces the dom that I want. People have become ver
 
 At any point in time, it might wake up again and, and, and for example, uh, process a payment for the monthly payments for some user or something like that. Um, it works the same way. It's just a program that you write the workflow in and it will, every time it needs to make a new decision, it just runs from scratch again.
 
-Right? And if something's already been done, it just skips it. Uh, and Alchemy is basically the same thing. It's just memorization of things that have been done and just a little bit of intelligent decision making as you go. Same. Same pattern. Yeah. 
+Right? And if something's already been done, it just skips it. Uh, and Alchemy is basically the same thing. It's just memorization of things that have been done and just a little bit of intelligent decision making as you go. Same. Same pattern. Yeah.
 
 **Andrew:** Yeah, we talked to Sunil Pi, one of the people that worked on the React Team way back, and he mentioned that they had a very similar. Demo where they had, like, it was way before React server components, but they had an application where they like specified a database as a component. So you like your whole app.
 
-The whole way down infrastructure to front end was just this one React application. So it was super cool idea. 
+The whole way down infrastructure to front end was just this one React application. So it was super cool idea.
 
 **Sam:** Yeah. I, I'm pretty psyched about like, that sounds like infrastructure from code, which was a whole thing back in the day. It's kind of a punch card, that product that. I mentioned before, although Punch Guard's execution is way outdated now, I'm pretty excited about alchemy enabling those kinds of use cases because now that infrastructure as code is not the weight of the universe, you know, it's not these three tools strung together.
 
@@ -229,7 +229,7 @@ Everyone can just always be on the latest version of language, use the best lang
 
 Uh. To your specific point about why it's great for configuration, it's like, well, 'cause it's Jason, right? It's basically programmable Jason with a type system that you can do more than just checking. You've got the right properties, you can encode the semantics of your tool or your service in there. Uh, for example, I wrote, uh, type, it's called Type Safe Dyna Moody B.
 
-It's another library that I built, which is. A type system implementation of DynamoDB semantics. So it'll type check the content of the query. So if you write an expression and you don't have the expression attribute value, it'll catch that. So I think that's why TypeScript is winning. You can see that now? 
+It's another library that I built, which is. A type system implementation of DynamoDB semantics. So it'll type check the content of the query. So if you write an expression and you don't have the expression attribute value, it'll catch that. So I think that's why TypeScript is winning. You can see that now?
 
 **Andrew:** Yeah, it's one, one of my favorite aspects of TypeScript is that you can just say F it and throw out the types completely. Like I was helping my, uh, my sister-in-law with some coding stuff, and it was in c plus plus, and we were hitting a compilation error. I'm like, I, I don't know. Usually I just say, just like, run, run it.
 
@@ -244,7 +244,7 @@ It should run. Yeah, definitely a different paradigm.
 
 #### [00:24:48] Embedding Alchemy in Any Runtime
 
-**Andrew:** ay, so one of the big features that you call out on the docs is that you can embed alchemy in any runtime. So why do you think that's, uh, so important? 
+**Andrew:** ay, so one of the big features that you call out on the docs is that you can embed alchemy in any runtime. So why do you think that's, uh, so important?
 
 **Sam:** Yeah, it's a good question. It's, it's the, it's one that I. was sort of noodling on. It's like. It's definitely a fact about alchemy, but there's def also some speculation there. We could talk about the browser, which we kind of mentioned, but I think the more interesting thing to talk about is CloudFlare durable objects.
 
@@ -266,7 +266,7 @@ You must have a file system. All these things are dependencies that just go on w
 
 But like the durable objects thing is, is really fascinating because it's like synchronized place where this thing is running, you know, very durable infrastructure for managing our infrastructure. And that's like kind of compelling. ~~Um,~~
 
-**Sam:** It's recursive. 
+**Sam:** It's recursive.
 
 **Justin:** Yeah. Yeah, I don't know. Uh, I'm
 
@@ -309,7 +309,7 @@ So, so that things can move along quicker, um, and then resolve consistency down
 
 Like being bricked from a partial state is terrible. Like they should, if I run this multiple times, it should get to the same state. That's a really important, important point. So with those in mind, and these are all encoded in the cursor rules file by the way, um, you can mostly just. Take the API spec past it in prompt, and you'll get most of it, and then you'll use it a few times by running the tests and find the edges and repair them as you find them.
 
-**Andrew:** Something you just said there. 
+**Andrew:** Something you just said there.
 
 
 #### [00:33:38] Optimizing Alchemy for Gen AI
@@ -334,7 +334,7 @@ Well when the file that I import changes, I probably should think about recomput
 
 Thinks about new use cases for that. That's pretty cool. I think there's a lot more that can be done there, but prompt engineering is hard and time consuming, and I'm not, not there yet, but that's, that's the AI story at the moment. ~~Yep.~~
 
-**Justin:** I wonder about like, so I, I think, I don't know. 
+**Justin:** I wonder about like, so I, I think, I don't know.
 
 
 #### [00:36:56] Solo Development and Future Plans
@@ -363,35 +363,35 @@ I could apply the same to. Another thing I've been experimenting with is event d
 
 So I I, my business ideas right now is venturing into that space. Yeah.
 
-**Andrew:** So your email has aspect sh on that. Is that at all tied into Alchemy? 
+**Andrew:** So your email has aspect sh on that. Is that at all tied into Alchemy?
 
 **Sam:** Uh, that was a, that was a previous spike of an idea that. Man, I have too many email aliases. Just, it's just another problem that I wish someone would solve. Uh, that's just a, a domain that I've got up my sleeve. I was working on a data product that was in that space. If you go to the, if you go to the, if you go to the website, you'll see that, uh, I, I've abandoned that for now, although I think it's a kick ass domain.
 
-It could have been a good, it could have been another good name for alchemy, actually, you know, like aspects. But I didn't have the NPM package, and I way prefer the NPM package than the domain. So went with alchemy aspect could become a pretty cool, like domain driven design product or something. Uh, but Yeah. it's, it's just an old school domain. 
+It could have been a good, it could have been another good name for alchemy, actually, you know, like aspects. But I didn't have the NPM package, and I way prefer the NPM package than the domain. So went with alchemy aspect could become a pretty cool, like domain driven design product or something. Uh, but Yeah. it's, it's just an old school domain.
 
-**Andrew:** Uh, dude, you, you could for sure get that MPM package name. They're super lenient with giving out parked names. This has not been updated in nine years and has no read me, so you could easily get that name. 
+**Andrew:** Uh, dude, you, you could for sure get that MPM package name. They're super lenient with giving out parked names. This has not been updated in nine years and has no read me, so you could easily get that name.
 
-**Sam:** Yeah. I've emailed that guy like three times. I think it's probably time to escalate 
+**Sam:** Yeah. I've emailed that guy like three times. I think it's probably time to escalate
 
-**Andrew:** Oh, yeah, e email support. You'll get it within like a day or two. I've done it a few times. 
+**Andrew:** Oh, yeah, e email support. You'll get it within like a day or two. I've done it a few times.
 
 **Sam:** good try. Good try. Yeah.
 
 **Justin:** You hear to hear from?
 
-**Sam:** Yeah. 
+**Sam:** Yeah.
 
-**Andrew:** Yeah, 
+**Andrew:** Yeah,
 
-**Sam:** one snip me now. 
+**Sam:** one snip me now.
 
 **Justin:** Yeah, yeah. We'll wait, we'll wait to publish this until you've had a
 
-**Sam:** Yeah. Yeah. Thanks. That's 
+**Sam:** Yeah. Yeah. Thanks. That's
 
-**Andrew:** yeah. We can edit it out too. That that's how I, that's I, I own auto on NPM, which is a very, very short Yeah. Yeah. 
+**Andrew:** yeah. We can edit it out too. That that's how I, that's I, I own auto on NPM, which is a very, very short Yeah. Yeah.
 
-**Sam:** I was trying to buy self ai. I think that's a really cool to name. It's listed as like a hundred dollars minimum offer, but I'm pretty sure they want like $2 million 
+**Sam:** I was trying to buy self ai. I think that's a really cool to name. It's listed as like a hundred dollars minimum offer, but I'm pretty sure they want like $2 million
 
 **Justin:** Oh, for sure. Yeah. Yeah.
 
@@ -426,9 +426,9 @@ It's hard to predict beyond that. But coverage and coverage and stability is the
 
 Like ask questions and maybe start thinking about how to contribute resources or use it, find what, what's missing, and build your own. I, I really love to see people try the AI generated experience. It's one of the most joyous things for me is. Having spent 10 years in, in, in infrastructure as code to just be able to click my fingers and get a new resource.
 
-It's just magic, you know? Uh, I'd like to see more people experience that and start thinking more about how well I can unbundle myself from all this mess and manage my own world. Uh, so yeah, I would say like, start the repo, join the discord. That would be the most helpful thing for me. 
+It's just magic, you know? Uh, I'd like to see more people experience that and start thinking more about how well I can unbundle myself from all this mess and manage my own world. Uh, so yeah, I would say like, start the repo, join the discord. That would be the most helpful thing for me.
 
-**Andrew:** Yeah, it'll be interesting to see what people build. It seems like you've built a very nice primitive that can be composed to do lots of new interesting things that might've been cumbersome in the past. So definitely excited to see what projects fall out of this. 
+**Andrew:** Yeah, it'll be interesting to see what people build. It seems like you've built a very nice primitive that can be composed to do lots of new interesting things that might've been cumbersome in the past. So definitely excited to see what projects fall out of this.
 
 **Sam:** Yeah, there's some, there's at least two people who are starting to really push into workers for platforms, so that's going to be really fun to see stacks of customer specific infrastructure. That's gonna be cool. ~~Uh, but yeah.~~
 
@@ -436,7 +436,7 @@ It's just magic, you know? Uh, I'd like to see more people experience that and s
 
 **Justin:** ~~Yeah. Yeah.~~
 
-**Andrew:** ~~questions? Okay, cool. Uh,~~ well that's it for our questions this week. Thanks for coming on, Sam. This was a very interesting delve into all things infrastructure as code where it seems like there's lots and lots of thorns to be had. So thanks for coming on and thanks for making the tool I. 
+**Andrew:** ~~questions? Okay, cool. Uh,~~ well that's it for our questions this week. Thanks for coming on, Sam. This was a very interesting delve into all things infrastructure as code where it seems like there's lots and lots of thorns to be had. So thanks for coming on and thanks for making the tool I.
 
 **Sam:** Yeah. Thanks for inviting me. This is great.
 
@@ -456,4 +456,4 @@ And that is so much more powerful than waiting on a team. I think one of the thi
 
 Something about this. Take your autonomy back in the and and just like be a solo team. Build the stuff you need. AI will do 90% of the work. Make good decisions. Yeah. Um, I think alchemy is the IAC revolution in that, in that philosophy.
 
-**Justin:** Exciting. 
+**Justin:** Exciting.

--- a/pages/episode/139.mdx
+++ b/pages/episode/139.mdx
@@ -1,9 +1,9 @@
 ---
 title: Zack Jackson - ByteDance, rspack, and the Future of Web Development
-sponsor: [WorkOS, Mailtrap]
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Zack-Jackson---ByteDance--rspack--and-the-Future-of-Web-Development-e31pf9h
 youtube: https://www.youtube.com/watch?v=Uo1Gf_32MK0
 tags: rspack, webpack, vite, byte dance, rust, javascript, typescript, react, react native, web development, web assembly, module federation, ecosystem, bundler, compiler, tooling
+sponsor: [WorkOS, Mailtrap]
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -46,7 +46,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Zack:** Whoever builds a compiler that produces the smallest bundle would most likely win the bundle of war.
 
-Regardless of how developers feel about it, or if they say, oh, well they love this ecosystem so much, that doesn't matter if you can produce 50% less payload. ​ 
+Regardless of how developers feel about it, or if they say, oh, well they love this ecosystem so much, that doesn't matter if you can produce 50% less payload. ​
 
 **Andrew:** Hello, welcome to Dev Tools fm. This is a podcast about developer tools and the people who make 'em. I'm Andrew, and this is my co-host Justin.
 
@@ -54,7 +54,7 @@ Regardless of how developers feel about it, or if they say, oh, well they love t
 
 Um, and so if anybody wants to go back and check out episode 30, we talked a lot, uh, about some like really interesting work you're doing at the time, and I hope to get some updates on that. But before we dive in, uh, would you like to update our listeners? Uh. And kind of tell the new listeners like about yourself and like, what are you up to these days?
 
-**Zack:** Uh, yeah, sure. 
+**Zack:** Uh, yeah, sure.
 
 
 #### [00:01:11] Zach's Role at Byte Dance
@@ -171,7 +171,7 @@ Then it's kind of nice to say, okay, well this becomes more of a preference choi
 
 And then it's really just what do you like using to do that job or what does it integrate with that you might also want.
 
-**Andrew:** A, a lot to dig into there. 
+**Andrew:** A, a lot to dig into there.
 
 
 #### [00:19:54] RS Pack: Innovations and Future Directions
@@ -261,7 +261,7 @@ I think this is where it would be nice to say, oh, well, links already uses this
 
 **Justin:** This episode is sponsored by MailTrap, an email platform that developers love. Go for high deliverability, industry best analytics, and live 24 7 support. You can get 20% off for all plans with a promo code dev tools. Check out the details in the description below.
 
-Yeah, Lynx is, LYX is such an interesting project and I think the thinking about the, the bundling. Uh, scenarios there is like really interesting. 
+Yeah, Lynx is, LYX is such an interesting project and I think the thinking about the, the bundling. Uh, scenarios there is like really interesting.
 
 
 #### [00:34:29] The Journey to RS Next
@@ -326,7 +326,7 @@ Someone who relies on it. So I think this was a really good way where it's like,
 
 Um, so yeah, you know, I think it really throws a lifeline to anybody who can't move. They can now get a nice DX improvement. We get a lot more, you know, eyeballs looking at it, and obviously we get like the best battle test that we could want, which is against, uh.
 
-**Andrew:** Yeah, it's cool to see more and more like shared foundations popping up between these projects. It, uh, it just lifts all the projects up, 
+**Andrew:** Yeah, it's cool to see more and more like shared foundations popping up between these projects. It, uh, it just lifts all the projects up,
 
 **Zack:** I think the, the, the, the big, the big thing there is like, it's, there's a, it's surprisingly few people who actually like, you know, that, that own a lot of these libraries or something like the, the. The, the, the group, the clusters of devs are really small, so it's really, really helpful when there's an opportunity to like work together because, you know, there's, there's, especially in Russ compared to JavaScript, it doesn't feel like you have the same like vast JS devs everywhere, like when you go to conferences and stuff like that, like rust isn't quite there yet.
 
@@ -381,7 +381,7 @@ It's such an important ecosystem and it's such a broad ecosystem,
 
 so It's great to see.
 
-**Zack:** It's something that you, you don't want to see die just because like times have changed and that was a big thing. Like it would be really nice to just keep it alive 'cause there's so many good things on there, it just needs to run quicker. 
+**Zack:** It's something that you, you don't want to see die just because like times have changed and that was a big thing. Like it would be really nice to just keep it alive 'cause there's so many good things on there, it just needs to run quicker.
 
 
 #### [00:54:30] Future Directions and Ecosystem Expansion

--- a/pages/episode/139.mdx
+++ b/pages/episode/139.mdx
@@ -1,5 +1,6 @@
 ---
 title: Zack Jackson - ByteDance, rspack, and the Future of Web Development
+sponsor: [WorkOS, Mailtrap]
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Zack-Jackson---ByteDance--rspack--and-the-Future-of-Web-Development-e31pf9h
 youtube: https://www.youtube.com/watch?v=Uo1Gf_32MK0
 tags: rspack, webpack, vite, byte dance, rust, javascript, typescript, react, react native, web development, web assembly, module federation, ecosystem, bundler, compiler, tooling

--- a/pages/episode/140.mdx
+++ b/pages/episode/140.mdx
@@ -1,5 +1,6 @@
 ---
 title: Eli Mallon - Streamplace and the future of decentralized video streaming
+sponsor: [WorkOS, Mailtrap]
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Eli-Mallon---Streamplace-and-the-future-of-decentralized-video-streaming-e323456
 youtube: https://www.youtube.com/watch?v=-xjd_iaULT0
 tags: atproto, blueksy, streamplace, video, streaming, twitch, live video

--- a/pages/episode/140.mdx
+++ b/pages/episode/140.mdx
@@ -1,14 +1,14 @@
 ---
 title: Eli Mallon - Streamplace and the future of decentralized video streaming
-sponsor: [WorkOS, Mailtrap]
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Eli-Mallon---Streamplace-and-the-future-of-decentralized-video-streaming-e323456
 youtube: https://www.youtube.com/watch?v=-xjd_iaULT0
 tags: atproto, blueksy, streamplace, video, streaming, twitch, live video
+sponsor: [WorkOS, Mailtrap]
 ---
 
 {/* TAB: SHOW NOTES */}
 
-This week we're joined by Eli Mallon, founder of Streamplace, a decentralized video streaming platform. 
+This week we're joined by Eli Mallon, founder of Streamplace, a decentralized video streaming platform.
 In this episode we discuss the future of decentralized video streaming, the challenges of building a new platform, and how developers can leverage Streamplace's tools.
 We also go into Atproto, the decentralized social media network that stream place is built on.
 
@@ -49,7 +49,7 @@ Become a paid subscriber our patreon, spotify, or apple podcasts for the full ep
 
 **Eli:** what really appeals to me about the space. They're not looking to just build one more centralized platform that gets acquired and forgotten about over the course of years.
 
-I really want to be building things that could endure for decades or hundreds of years, um, when people are looking back. 
+I really want to be building things that could endure for decades or hundreds of years, um, when people are looking back.
 
 ### [00:00:19] Introduction
 
@@ -63,7 +63,7 @@ I love the streamers on that platform, but don't love that platform for, for lot
 
 And, uh, since last July I've been working full-time on Stream Place, which is live video for the app protocol. So if we are, um, if, uh, if Blue Sky's trying to make Twitter using the app protocol, we are trying to make Twitch using the app protocol is the short explanation of that.
 
-**Andrew:** Cool. 
+**Andrew:** Cool.
 
 
 ### [00:01:46] Understanding Decentralized Video and Live Peer
@@ -191,7 +191,7 @@ Um, so yeah, one way I hope we can push the life peer network forward as well.
 
 **Justin:** This episode is sponsored by MailTrap, an email platform that developers love. Go for high deliverability, industry best analytics, and live 24 7 support. You can get 20% off for all plans with a promo code dev tools. Check out the details in the description below.
 
-Um, shift the conversation a little bit. 
+Um, shift the conversation a little bit.
 
 
 ### [00:19:16] Monetization Challenges in Decentralized Platforms
@@ -406,4 +406,4 @@ So, uh, really hoping to pick up the, the velocity pick, uh, you know, polish of
 
 **Justin:** Great. Thanks Eli. I'm really excited to see what you'll build.
 
-**Eli:** Thanks very much. 
+**Eli:** Thanks very much.

--- a/pages/episode/141.mdx
+++ b/pages/episode/141.mdx
@@ -3,6 +3,7 @@ title: Anirudh and Akshay from Tangled.sh and the Future of Decentralized Coding
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Anirudh-and-Akshay-from-Tangled-sh-and-the-Future-of-Decentralized-Coding-e32co3m
 youtube: https://youtu.be/watch?v=7kHJNCHQiyg
 tags: atproto, blueksy, git, decentralized, coding
+sponsor: [WorkOS, Mailtrap]
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/142.mdx
+++ b/pages/episode/142.mdx
@@ -3,6 +3,7 @@ title: James Garbutt - E18e
 youtube: https://youtu.be/watch?v=u_j3YlZ9XKQ
 spotify: https://creators.spotify.com/pod/show/justin8991/episodes/James-Garbutt---e18e-e32n9uk
 tags: JavaScript, performance, e18e, open source, npm, package optimization, bundle size, web performance, OSS, developer tools, frontend, code cleanup, node.js
+sponsor: [WorkOS, Mailtrap]
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/142.mdx
+++ b/pages/episode/142.mdx
@@ -19,6 +19,8 @@ We discuss:
 
 If you care about build times, bundle sizes, and the health of the JavaScript ecosystem, this episode is for you.
 
+Episode sponsored By WorkOS (https://workos.com) and Mailtrap (https://l.rw.rw/devtools_3)
+
 {/* LINKS */}
 
 🔗 Links
@@ -45,7 +47,7 @@ If you care about build times, bundle sizes, and the health of the JavaScript ec
 {/* TAB: TRANSCRIPT */}
 
 
-**James:** the hot path in terms of the dependency that most people pull in doesn't really need to support that far back. So the whole thing was to create alternatives, than trying to get rid of whatever it is that's pulling all those in. 
+**James:** the hot path in terms of the dependency that most people pull in doesn't really need to support that far back. So the whole thing was to create alternatives, than trying to get rid of whatever it is that's pulling all those in.
 
 
 ## [00:00:21] Introduction
@@ -232,8 +234,6 @@ It's not a separate thing. You install it will be the new CLI at some point. the
 
 **Justin:** Yeah, absolutely. Thanks again, James for coming on and thanks for your work for the community. I'm excited that this initiative exists and yeah, hopefully we'll see some good stuff in the future.
 
-**James:** Yeah, no worries. Thanks for having me. 
+**James:** Yeah, no worries. Thanks for having me.
 
-​ 
-
-
+​

--- a/pages/episode/143.mdx
+++ b/pages/episode/143.mdx
@@ -3,6 +3,7 @@ title: Stepan Parunashvili - InstantDB
 youtube: https://www.youtube.com/watch?v=t3QxNe2VEhk
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Stepan-Parunashvili---InstantDB-e331cl4
 tags: InstantDB, Database, Local First, Serverless, React, TypeScript, JavaScript, Firebase, Meteor, Luna, Figma
+sponsor: [WorkOS, Mailtrap]
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/144.mdx
+++ b/pages/episode/144.mdx
@@ -3,6 +3,7 @@ title: Greg Sadetsky, Antoine Leclair - Disco
 youtube: https://www.youtube.com/watch?v=Xr3JJpbCRP0
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Greg-Sadetsky--Antonie-Leclair---Disco-e33bjbd
 tags: open source, infra, dev tools, web development, raspberry pi, hosting, web apps, cloud, disco
+sponsor: [WorkOS, Mailtrap]
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/145.mdx
+++ b/pages/episode/145.mdx
@@ -3,6 +3,7 @@ title: Peter Pistorius - Redwood SDK
 youtube: https://www.youtube.com/watch?v=y6r9q07Nvfg
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Peter-Pistorius---Redwood-SDK-e33lqf6
 tags: redwood, open source, infra, dev tools, web development, raspberry pi, hosting, web apps, cloud, cloudflare, serverless, lambda, react, graphql, orm, middleware, routing, plugin system, auth, durable objects, database, file storage, queues, cdn
+sponsor: [WorkOS, Mailtrap]
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/146.mdx
+++ b/pages/episode/146.mdx
@@ -3,6 +3,7 @@ title: Dylan Piercey - Marko
 youtube: https://www.youtube.com/watch?v=7gAfc1ADnB8
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Dylan-Piercey---Marco-e349n2k
 tags: Marko, javascript, framework, web development, react, react server components, streaming, islands architecture, bundler, typescript, tooling, development, optimization, performance, html, jsx, language, syntax, compiler, bundler, react, react server components, streaming, islands architecture, typescript, tooling, development, optimization, performance, html, jsx, language, syntax, compiler, bundler
+sponsor: WorkOS
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/147.mdx
+++ b/pages/episode/147.mdx
@@ -3,6 +3,7 @@ title: Maxim Fateev - Temporal
 youtube: https://www.youtube.com/watch?v=94vJSZ_sCVg
 spotify: https://creators.spotify.com/pod/show/devtoolsfm/episodes/Maxim-Fateev---Temporal-e34jcbh
 tags: temporal, developer, programming, workflows, durable execution
+sponsor: WorkOS
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/63.mdx
+++ b/pages/episode/63.mdx
@@ -3,6 +3,7 @@ title: Daniel Roe - Nuxt, unJS
 youtube: https://www.youtube.com/watch?v=Ja-E3OJ7Ezs
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Daniel-Roe---Nuxt--unJS-e28ille
 tags: web dev, vue, nuxt, unjs, react, next, svelte, vite, typescript, javascript, node, deno, css, html, design, dev, developer, development, devtools, dev tools
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/64.mdx
+++ b/pages/episode/64.mdx
@@ -3,6 +3,7 @@ title: Nate Wienert - Tamagui
 youtube: https://www. youtube.com/watch?v=oEVI4WbTvQo
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Nate-Wienert---Tamagui-e28rhe8
 tags: react native, react, ui, design system, compiler, cross platform, development, web, native, mobile, tamagui, devtools
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/65.mdx
+++ b/pages/episode/65.mdx
@@ -3,6 +3,7 @@ title: Corbin Crutchley - Framework Field Guide (learn React, Angular, Vue at th
 youtube: https://www.youtube.com/watch?v=BiwPAw4Qpos
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Corbin-Crutchley---Framework-Field-Guide-learn-React--Angular--Vue-at-the-same-time-e294d5v
 tags: technology,programming,software,tools,developer tools,learning,react,vue,angular,framework,frameworks,open source,github,github stars,github star,corbin crutchley,corbin,crutchley,unicorn utterances,unicorn,utterances,houseform,house,form,tanstack,tanstack form,tanstackform,tanner lindsley,tanner,lindsley,react hook form,react-hook-form,reacthookform,formic,formik,forms,cli,command line,command line interface,commandline,commandline interface,plop,jimp
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/66.mdx
+++ b/pages/episode/66.mdx
@@ -3,6 +3,7 @@ title: Josh Goldberg - TypeScript ESLint
 youtube: https://www.youtube.com/watch?v=8xfHlnhuMWQ
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Josh-Goldberg---TypeScript-ESLint-e29dgsr
 tags: typescript, eslint, prettier, tooling, javascript, typescript-eslint, open source, linting, static analysis, static typing, developer tools, software engineering, software development, web development, programming
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/67.mdx
+++ b/pages/episode/67.mdx
@@ -3,6 +3,7 @@ title: James Pearce - TinyBase
 youtube: https://www.youtube.com/watch?v=hXL7OkW-Prk
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/James-Pearce---TinyBase-e29nlh8
 tags: technology, software, developer tools, devtools, devtools.fm, James Pearce, TinyBase, Meta, Facebook, Portal, React, React Native, PyTorch, Llama, Llama 2, Local First, Local First Web Development, Ink and Switch, TinyQL, TinyQL Playground, TinyQ
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/68.mdx
+++ b/pages/episode/68.mdx
@@ -3,6 +3,7 @@ title: Eric Elliott - SudoLang
 youtube: https://www.youtube.com/watch?v=2EAJLYmKiog
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Eric-Elliott---SudoLang-e2a1eun
 tags: technology, programming, developer tools, devtools, javascript, ai, artificial intelligence, machine learning, gpt3, gpt4, chatgpt, sudolang, pseudo, pseudo code, code, programming language, language model, language models, react, python, javascript, solidity
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/69.mdx
+++ b/pages/episode/69.mdx
@@ -3,6 +3,7 @@ title: Aiden Bai - Million.js
 youtube: https://www.youtube.com/watch?v=qLVQCE1zAMw
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Aiden-Bai---Million-js-e2aansm
 tags: javascript, react, million.js, open source, community, performance, open source, frontend, web development, web dev, devtools, devtoolsfm
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/70.mdx
+++ b/pages/episode/70.mdx
@@ -3,6 +3,7 @@ title: Emanuele Stoppa - Biome
 youtube: https://www.youtube.com/watch?v=Vx8SzrqIJHo
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Emmanuele-Stoppa---Biome-e2akb29
 tags: technology, software development, developer tools, dev tools, rome, biome, rust, linter, formatter, typescript, javascript, css, html, ast, cst, compiler, cli, daemon, lsp, language server, plugins, extism, typescript, import, eslint, typescript, javascript, css, html
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/71.mdx
+++ b/pages/episode/71.mdx
@@ -3,6 +3,7 @@ title: Vlad A. Ionescu - Earthly
 youtube: https://www.youtube.com/watch?v=ue-uDEwXRBg
 spotify: https://podcasters.spotify.com/devtoolsfm/episodes/Vlad-A--Ionescu---Earthly-e2at2uf
 tags: technology, devtools, earthly, ci, cd, build, automation, container, containerization, docker, kubernetes, github, gitlab, bitbucket, azure, aws, gcp, google, cloud, platform, azure, devops, jenkins, circleci, travis, github, actions, gitlab, ci, cd, pipelines, build, automation
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/72.mdx
+++ b/pages/episode/72.mdx
@@ -3,6 +3,7 @@ title: Dax Raad - SST
 youtube: https://www.youtube.com/watch?v=V_2OLtsD0N8
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Dax-Raad---SST-e2b7kn7
 tags: technology, aws, serverless, sst, infrastructure, cloud, cloud computing, cloud native, cloud development, cloud development kit, cdk, terraform, pulumi, cloudflare, vercel, netlify, nextjs, react, javascript, typescript, nodejs, deno
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/74.mdx
+++ b/pages/episode/74.mdx
@@ -4,6 +4,7 @@ youtube: https://www.youtube.com/watch?v=1f-4Y-hbomQ
 thumbnail: https://www.youtube.com/watch?v=9qS55iBBWl0
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Isaac-Schlueter---npm--Tier-e2bralq
 tags: technology, npm, node, javascript, open source, tier, pricing, cjs, esm, startups, company, founder, ceo, package manager
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/75.mdx
+++ b/pages/episode/75.mdx
@@ -4,6 +4,7 @@ youtube: https://www.youtube.com/watch?v=Z2Anm7_V-dc
 thumbnail: https://www.youtube.com/watch?v=CTVDE2JSwQ4
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Braden-Sidoti---Clerk-e2c52of
 tags: technology, auth, security, startups, business, developer tool, coding, programming, frontend, backend
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/76.mdx
+++ b/pages/episode/76.mdx
@@ -3,6 +3,7 @@ title: Matteo Collina - Node.js, Fastify, Platformatic
 youtube: https://www.youtube.com/watch?v=0s46TVPIa9g
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Matteo-Collina---Node-js--Fastify--Platformatic-e2cehlk
 tags: tech, nodejs, fastify, platformatic, javascript, open source, community, esm, cjs, backend, frontend, web, development, devtools, devtoolsfm
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/77.mdx
+++ b/pages/episode/77.mdx
@@ -3,6 +3,7 @@ title: Yagiz Nizipli - Node.js Performance
 youtube: https://www.youtube.com/watch?v=waEKI4V70CU
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Yagiz-Nizipli---Node-js-Performance-e2cp1ld
 tags: technology, node.js, performance, rust, wasm, v8, javascript, webassembly, url, parser, benchmark, simd, utf, simdjson, simdutf, nodejs, deno
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/78.mdx
+++ b/pages/episode/78.mdx
@@ -3,6 +3,7 @@ title: Jess Martin - DXOS
 youtube: https://www.youtube.com/watch?v=pfbCT04WPBE
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Jess-Martin---DXOS-e2d356c
 tags: tech, podcast, dxos, crdts, sqlite, local first, data, identity, interoperability, collaboration, real time, web, p2p, peer to peer, web native, decentralized
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/79.mdx
+++ b/pages/episode/79.mdx
@@ -3,6 +3,7 @@ title: Brian Douglas - Open Sauced, GitHub
 youtube: https://www.youtube.com/watch?v=f6wyKND4BJw
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Brian-Douglas---Open-Sauced--GitHub-e2dbi7q
 tags: tech, dev, open source, github, devrel, devtools, devtoolsfm, brian douglas, open sauced, github
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/80.mdx
+++ b/pages/episode/80.mdx
@@ -3,6 +3,7 @@ title: Eric Simons - StackBlitz
 youtube: https://www.youtube.com/watch?v=w4l89214zN4
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Eric-Simons---StackBlitz-e2e4vfr
 tags: tech, web, javascript, react, angular, vue, svelte, webassembly, webcontainers, stackblitz, aol, startup, entrepreneurship, developer-tools, devtools, devtoolsfm, podcast
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/81.mdx
+++ b/pages/episode/81.mdx
@@ -3,6 +3,7 @@ title: Feross Aboukhadijeh - Socket
 youtube: https://www.youtube.com/watch?v=GzSmY-8v_Ow
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Feross-Aboukhadijeh---Socket-e2eei17
 tags: security, open source, webtorrent, decentralization, socket, feross, javascript, node, npm, github, funding, maintainer, maintainer burnout, typescript, python
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/82.mdx
+++ b/pages/episode/82.mdx
@@ -3,6 +3,7 @@ title: Daniel Thompson-Yvetot, Lucas Nogueira - Tauri
 youtube: https://www.youtube.com/watch?v=2AcyhLGy5Ss
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Daniel-Thompson-Yvetot--Lucas-Nogueira---Tauri-e2eocjn
 tags: tauri, electron, rust, crab nebula, security, governance, technology, programming, coding, software, open source
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/83.mdx
+++ b/pages/episode/83.mdx
@@ -3,6 +3,7 @@ title: Christopher "vjeux" Chedeau - Prettier, React Native
 youtube: https://www.youtube.com/watch?v=aIab6mpN7LI
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Christopher-vjeux-Chedeau---Prettier--React-Native-e2f2g2f
 tags: technology, prettier, javascript, rust, react, react-native, css-in-js, ai, video-editing, open-source, meta, facebook, babel, eslint, webpack, typescript, gofmt, go, php, apache, mysql, memcache, xhp, jsx, yoga, lama, pytorch, excalidraw
+sponsor: Raycast
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/84.mdx
+++ b/pages/episode/84.mdx
@@ -2,7 +2,8 @@
 title: Evan Bacon - Expo
 youtube: https://www.youtube.com/watch?v=Hnh5ew0jfKQ
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Evan-Bacon---Expo-e2fcbvn
-tags: technology, mobile, react, react native, expo, react navigation, expo router, web, native, css, metro, bundling, vision os, 
+tags: technology, mobile, react, react native, expo, react navigation, expo router, web, native, css, metro, bundling, vision os,
+sponsor: CodeCrafters 
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/85.mdx
+++ b/pages/episode/85.mdx
@@ -3,6 +3,7 @@ title: Zeno Rocha - React.Email, Resend, Dracula Theme
 youtube: https://www.youtube.com/watch?v=3Nyw52eazcs
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Zeno-Rocha---React-Email--Resend--Dracula-Theme-e2flj83
 tags: tech, open source, react, email, resend, dracula, theme, design, development, developer, tools, devtools, devtools.fm, podcast, software development, front end, back end
+sponsor: CodeCrafters
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/86.mdx
+++ b/pages/episode/86.mdx
@@ -3,6 +3,7 @@ title: Glauber Costa - Forking SQLite and Building a Distributed Database with T
 youtube: https://www.youtube.com/watch?v=5wZPUIhJUBk
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Glauber-Costa---Forking-SQLite-and-Building-a-Distributed-Database-with-Turso-e2g0njh
 tags: tech, sqlite, databases, open source, distributed systems, cloud computing, serverless, linux, kernel, replication, turso, libsql, glauber costa
+sponsor: CodeCrafters
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/87.mdx
+++ b/pages/episode/87.mdx
@@ -3,6 +3,7 @@ title: Robert Balicki - Isograph, Relay, and the Future of Data Fetching in Reac
 youtube: https://www.youtube.com/watch?v=hXuACmQJQTg
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Robert-Balicki---Isograph--Relay--and-the-Future-of-Data-Fetching-in-React-e2g9298
 tags: react, relay, isograph, graphql, data fetching, react server components, frontend, web development, tooling, browser, webassembly, rust, pinterest, facebook, meta, backend, javascript, performance, optimization, devtools, developer tools
+sponsor: CodeCrafters
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/88.mdx
+++ b/pages/episode/88.mdx
@@ -3,6 +3,7 @@ title: Herrington Darkholme - AST Grep, Searching Code with Code
 youtube: https://www.youtube.com/watch?v=zd2XTm5If_o
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Herrington-Darkholme---AST-Grep--Searching-Code-with-Code-e2gjk7h
 tags: ast, grep, code, search, javascript, rust, vue, compiler, tree-sitter, yaml, rules, testing, plugins, vscode, webassembly
+sponsor: [CodeCrafters, RunMe]
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/89.mdx
+++ b/pages/episode/89.mdx
@@ -3,6 +3,7 @@ title: Dani Grant - Jam.dev, One click bug reports developers love
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Dani-Grant---Jam-dev--One-click-bug-reports-developers-love-e2gt5b4
 youtube: https://www.youtube.com/watch?v=-KEvfnAp854
 tags: tech, podcast, jam, dev tools, software, product management, collaboration, AI, bug reporting, leadership, startup, founder, product, fund raising
+sponsor: [CodeCrafters, RunMe]
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/90.mdx
+++ b/pages/episode/90.mdx
@@ -3,6 +3,7 @@ title: DHH - Ruby on Rails, 37signals, and the future of web development
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/DHH---Ruby-on-Rails--37signals--and-the-future-of-web-development-e2h699i
 youtube: https://www.youtube.com/watch?v=rEZNbM4MUdo
 tags: technology, rails, ruby, web development, 37signals, DHH, podcast, dev tools, javascript, typescript, html, software engineering, programming
+sponsor: [CodeCrafters, RunMe]
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/91.mdx
+++ b/pages/episode/91.mdx
@@ -3,7 +3,7 @@ title: Guillermo Rauch - Vercel, The Front End Cloud
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Guillermo-Rauch---Vercel--The-Front-End-Cloud-e2hh01i
 youtube: https://www.youtube.com/watch?v=JMHb5KpV1-k
 tags: technology, Vercel, front end, customer experience, developer tools, open source, react, server components, generative UI, AI, apps, software development, web development, cloud, dev tools
-sponsor: [CodeCrafters, Vercel]
+sponsor: CodeCrafters
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -17,7 +17,7 @@ We also talk about AI and generative UI, and how it might change the future of s
 - https://github.com/rauchg/Socket.IO
 - https://vercel.com/
 
-Episode sponsored By CodeCrafters (https://codecrafters.io/devtoolsfm) 40% Discount!  
+Episode sponsored By CodeCrafters (https://codecrafters.io/devtoolsfm) 40% Discount!
 
 Become a paid subscriber our patreon, spotify, or apple podcasts for the full episode.
 
@@ -59,11 +59,11 @@ Um, so we're really excited to have you on. Before we dive into the questions, w
 
 #### [00:01:17] The Evolution of Guillermo's Career and the Birth of Vercel
 
-**Andrew:** Cool. So, uh, you, before Vercel, you had a long life as an open source person. Uh, you'd had a lot of really cool projects. You were the creator of socket . io. I was visiting the new tools page and I saw your old picture with, yeah. With, with your emo haircut, fun to see. Uh, so from those days. 
+**Andrew:** Cool. So, uh, you, before Vercel, you had a long life as an open source person. Uh, you'd had a lot of really cool projects. You were the creator of socket . io. I was visiting the new tools page and I saw your old picture with, yeah. With, with your emo haircut, fun to see. Uh, so from those days.
 
 **Guillermo:** yes, I was 16.
 
-**Andrew:** Oh, wow. Yeah. So from those days, how did, how did those tools and ideas shape where you went with your career and where Vercel is at today? 
+**Andrew:** Oh, wow. Yeah. So from those days, how did, how did those tools and ideas shape where you went with your career and where Vercel is at today?
 
 **Guillermo:** It's funny you mentioned Socket. io because a lot of people still get surprised that I created Socket. io. They say, holy shit, the Vercel CEO created Socket. io and it is surprising to me even in that, like, I didn't start a company for Socket. io. Like that thing became so popular, I got lucky in that I, I think I hit really good timing with a open source solution for building real time web applications. Real time Everything has sort of been the calling of my career. If you think about what we do today at Vercel is really making everything real time, like make the deployment process feel real time, iterating really quickly on projects. Socket. io was amazing because I was able to give the world a solution for something that everybody wanted, which was create this real time applications that are like chat, like interactive, et cetera.
 
@@ -91,41 +91,41 @@ The reality is that they don't care that much about like each knob and each gear
 
 Especially for the largest companies in the world. And so we kind of, uh, I was able to create a technology that kind of satisfied both needs. And, uh, yeah, turned out pretty well. But I mean, embedded in a huge way to Meta, open source in React and, uh, Google open source and a bunch of other cool things like Kubernetes.
 
-We can get into the infrastructure side of things if you want. Uh, but yeah, building an open source was a huge part of what makes it successful. 
+We can get into the infrastructure side of things if you want. Uh, but yeah, building an open source was a huge part of what makes it successful.
 
 **Andrew:** Yeah, I can see that theme of making a complicated, tool simple with like, the first product I knew from ZEIT, uh, now, you just run now at your CLI and you get something pushed to the cloud. so since those days, uh, the company's changed a lot. It's got a different name, uh, a few different products.
 
-Like the first thing I actually associated you guys with was a terminal of all things. 
+Like the first thing I actually associated you guys with was a terminal of all things.
 
-**Guillermo:** That's awesome. I was just tuning my terminal yesterday and I was like, terminals are freaking awesome. And that's why we started that project. But it was a total side 
+**Guillermo:** That's awesome. I was just tuning my terminal yesterday and I was like, terminals are freaking awesome. And that's why we started that project. But it was a total side
 
-quest. 
+quest.
 
 
 #### [00:07:40] Ad
 
-**Andrew:** We'd like to thank our sponsor for the week code crafters. 
+**Andrew:** We'd like to thank our sponsor for the week code crafters.
 
-Code crafters makes programming challenges for experienced software engineers. If you're looking for a weekend project that takes you to the edge of your programming abilities, you got to check them out. Uh, I've, I've worked through a few of their challenges now. Uh, I've done the builder on Reddis, which was a fun introduction. I leveled up to do the build your own get, which was a much larger challenge. 
+Code crafters makes programming challenges for experienced software engineers. If you're looking for a weekend project that takes you to the edge of your programming abilities, you got to check them out. Uh, I've, I've worked through a few of their challenges now. Uh, I've done the builder on Reddis, which was a fun introduction. I leveled up to do the build your own get, which was a much larger challenge.
 
-One of the cool things about code crafters is not only are you learning to do some programming language better and learn about some modern tool. You're also learning how to like sift through their code, sift through their docs, learn about their protocols and really get to the bones of how these services actually work. I haven't started it yet, but my next challenge. For the last leg of this sponsorship it's to try to build my own SQL light. On the podcast. 
+One of the cool things about code crafters is not only are you learning to do some programming language better and learn about some modern tool. You're also learning how to like sift through their code, sift through their docs, learn about their protocols and really get to the bones of how these services actually work. I haven't started it yet, but my next challenge. For the last leg of this sponsorship it's to try to build my own SQL light. On the podcast.
 
-We've had lots of companies and products come on that are built around SQL Lite and all the cool things that it enables. So I think it would be pretty cool to get to learn how it actually works. 
+We've had lots of companies and products come on that are built around SQL Lite and all the cool things that it enables. So I think it would be pretty cool to get to learn how it actually works.
 
-If you asked me learning, like this is way better than grinding on some leak code, you actually would get to build real skills and have fun while doing it. 
+If you asked me learning, like this is way better than grinding on some leak code, you actually would get to build real skills and have fun while doing it.
 
 Besides the content, even these are experiences targeted towards experienced software developers. For example, instead of trying to tie you into a custom in browser experience to edit code code crafters, let's use your ID and your terminal. So you work as you normally would. Push up to code crafters, they run the test and they tell you if you pass, you asked me, it's pretty cool.
 
 Just try out code crafters for yourself. Visit code crafters.io/dev tools. Dash FM. There you'll get a 40% discount and you'll be helping out the podcast a little bit too.
 
-That's not the only way to help out the podcast. You can become a paid member. If you become a paid member, you get access to our episodes a little bit early and you never have to hear any of these ads again. 
+That's not the only way to help out the podcast. You can become a paid member. If you become a paid member, you get access to our episodes a little bit early and you never have to hear any of these ads again.
 
 If you want a sponsor dev tools, FM, head over to dev tools.fm/sponsor to apply. And with that, let's get back to the episode.
 
 
 #### [00:09:33] Vercel's Vision: Democratizing Web Development for Ambitious Projects
 
-**Andrew:** So how would you explain the company Vercell to someone who doesn't know anything about it right now? 
+**Andrew:** So how would you explain the company Vercell to someone who doesn't know anything about it right now?
 
 **Guillermo:** Yeah, I think every business today is becoming a digital business. That's like what we all agree upon. Right. And becoming a digital business is actually really, really hard. Even though there's things like the cloud and AWS and like all this amazing open source knowledge, doing something at the level of the giants of the web, like Amazon, Google meta is extremely hard, but that's today's battlefield.
 
@@ -151,11 +151,11 @@ But today I give you sort of. The ambition of creating the best products. When I
 
 Like companies like Google, I think Google has the largest monorepo in the world, like billions of lines of code. And I wanted to democratize that technology. Now that technology, again, it's a point solution in the service of you create amazing experiences on the internet, amazing products for your customers.
 
-I think when I say keep reflecting on like what truly makes us different as a company and as a group of people on a DNA level, is that we're obsessed with customer experience. We call ourselves the front end cloud because we propose that teams start building front and first. Start with the customer, start with what you want to deliver, start with how fast it is, how dynamic it is, and then work backwards into the technology. 
+I think when I say keep reflecting on like what truly makes us different as a company and as a group of people on a DNA level, is that we're obsessed with customer experience. We call ourselves the front end cloud because we propose that teams start building front and first. Start with the customer, start with what you want to deliver, start with how fast it is, how dynamic it is, and then work backwards into the technology.
 
 **Andrew:** Yeah. Through that lens, it makes a lot of the things that you guys have done recently and make a lot of sense. So like one joke you might see about, uh, Vercell on Twitter is that they just wrap services. But that is exactly what you're saying is that we want to wrap these services so that. We've democratized them and make them easy to deploy for anybody.
 
-Cause like on Vercel, I want to run on the edge. I just export a variable. Oh, I want to have a Postgres database, key value store. Oh, right there, right off the shelf. 
+Cause like on Vercel, I want to run on the edge. I just export a variable. Oh, I want to have a Postgres database, key value store. Oh, right there, right off the shelf.
 
 **Guillermo:** Yeah, that's a really good point. That's exactly how we architect. So first is what do you need to solve? What experience do you want to deliver? And then we work backwards into the how and we abstract out the how from you so that you don't have to worry about it. So you, you hire us to do that, that sort of legwork.
 
@@ -177,12 +177,12 @@ js, when you build with Nuxt, you're building the customer facing part of the ex
 
 Thanks. But also we see the community of framework creators as our customers as well. So we support like 40 frameworks, I believe, out of the box. So by getting the inputs of Sebastian and getting the inputs of Rich, we're building the best possible platform.
 
-**Andrew:** 
+**Andrew:**
 
 
 #### [00:19:11] Embracing React Server Components: The Future of Web Development
 
-**Andrew:** so recently, uh, you guys have been working towards a pretty big goal of React server components. Uh, I've read on Twitter that like, basically you guys. Are the people who invested in it and it's why it's really even a thing. So as a company, why did you guys think that RSC was the right bet to make? 
+**Andrew:** so recently, uh, you guys have been working towards a pretty big goal of React server components. Uh, I've read on Twitter that like, basically you guys. Are the people who invested in it and it's why it's really even a thing. So as a company, why did you guys think that RSC was the right bet to make?
 
 **Guillermo:** Yeah, it's a great question because I created Next. js and I had a lot of influence. Over the design of the pages router. So to replace that is like killing your baby. You know, like I love my baby pages router. And I honestly do, like we've done incredible things with, with it. If you think about all the companies that we've served, one of the things that used to be really hard for, um, I think for the internet in general, but for, for Rocelle was the customer built something, they launch it and he needs to scale to like Unknown amounts, amounts of traffic, and it has to be very efficient.
 
@@ -222,13 +222,13 @@ And of course today you can still cache the entire page if you want, but the fac
 
 It means deploying more fearlessly because you're not sort of hurting the existing experience umm Generally speaking, it's been exciting to see how everybody's adopting it for new projects as well. Figma. com, for example, just migrated from, interestingly enough, Gatsby into the Next. js app router. So it's always awesome to see.
 
-To me, something I've always felt really proud of is, The companies that I respect, the tools that I use, the folks that I want to work with using our tools, right? And so Stripe launched their Black Friday experience on the Next. js App Router, Figma. com, a lot of awesome websites are adopting it and, uh, and we continuously improve it, 
+To me, something I've always felt really proud of is, The companies that I respect, the tools that I use, the folks that I want to work with using our tools, right? And so Stripe launched their Black Friday experience on the Next. js App Router, Figma. com, a lot of awesome websites are adopting it and, uh, and we continuously improve it,
 
 **Andrew:** Yeah, the, the app router is really interesting. It just allows you to craft your code in such a different way. Like the thing that one of the tweets from you that made it click for me was somebody was like, what's the equivalent of like get static props for, for this. And he's like that you're just like, that's it.
 
-That's, that's the whole thing. You can use that. But at any point in the tree now, and I think that's just so simple and really 
+That's, that's the whole thing. You can use that. But at any point in the tree now, and I think that's just so simple and really
 
-unlocks a lot of cool things. 
+unlocks a lot of cool things.
 
 **Guillermo:** And you know what's funny? That was the, that was the top feature request for so many years. So something that's been great about react evolving in this way is that we'd get all this feature requests and we literally could do nothing about them. So when we launched get static props and get server side props, People would say, awesome, I want exactly that, you nailed it, but please give it to me on the component level. And I was like, well, there's almost no way I can do this. Layouts is another great example of, we've been, people have been asking for layouts for so many years. And we didn't do it for so many years because we couldn't find a way that it would be sustainably implemented. We knew what was coming ahead for React.
 
@@ -238,9 +238,9 @@ They were like, okay, React, like now you take over. And in that way, Next. js P
 
 So I flush and I stream the fallback, and now I continue down the tree. Oh, I need some more data. Maybe I can fetch it from the cache. Maybe I render, I stream it to the end user. So, um, in a nutshell, It's been amazing to see that React is taking more of the burden of what we needed, and in many ways couldn't implement.
 
-And now Next. js can sort of be, it's It realizes full vision, 
+And now Next. js can sort of be, it's It realizes full vision,
 
-**Andrew:** Yeah, in practice, it kind of just makes the whole API melt away. It's like, I don't, I'm not really caring about like using next JS APIs to get my data. I don't really have to make API routes. That's just, that's just part of my app and it all just kind of fits together. 
+**Andrew:** Yeah, in practice, it kind of just makes the whole API melt away. It's like, I don't, I'm not really caring about like using next JS APIs to get my data. I don't really have to make API routes. That's just, that's just part of my app and it all just kind of fits together.
 
 **Guillermo:** Yeah. I remember a conversation I had with, uh, Seb at one point and I was like, it's almost like he made me realize that creating an API and creating a react front end, we're almost like two products. So if you think about, think about what comes to mind when you think world class API, you think, well, like.
 
@@ -248,13 +248,13 @@ Stripe and their awesome documentation and how they authorize API calls and how 
 
 So most people need to create just some application on the web. If we ask them to create an API, we're now asking them to create another application. And that comes with security implications. They have to like, think about how to secure an API endpoint, which will get exposed to the entire internet, how to document it, open API specs, and so on and so forth.
 
-And then they need to worry about implementing their product. So to your point, it feels like the present is just very streamlined. 
+And then they need to worry about implementing their product. So to your point, it feels like the present is just very streamlined.
 
 **Justin:** Yeah, I feel this really strongly in my time at oxide is like thinking about the API is like the entry point of the product was like a really strong motivator. And it is like, it's a very different mindset when you're crafting a big API. And we kind of see, and I like next chess has really helped drive.
 
 This is like, we see, like, Originally it was like, oh yeah, we'll either server side render the whole page, you know, really old school style, or, you know, we'll break it apart and we'll do a spot on an API. And then it like kind of got a little bit closer. It's like, okay, now we're building back ends for front ends.
 
-And the model like scaled really well. Cause people realize it's like, they were just building APIs because it was like the thing to do. It's like, oh yeah, we need an API for our service. 
+And the model like scaled really well. Cause people realize it's like, they were just building APIs because it was like the thing to do. It's like, oh yeah, we need an API for our service.
 
 
 #### [00:33:26] The Evolution of Building for the Web: From Monoliths to Modern Approaches
@@ -271,14 +271,14 @@ Like a mainframe, like an SAP app or whatever. But the experience of building ha
 
 And that's when we need to explain, no, no, no, but we're bringing the future into it. Um, and yeah, so, I, I, some people get frustrated about the pendulum swings. But I've never seen the industry fully pendulum swing. It's not like we're building exactly like we're building with php right? We have this rich client side model now.
 
-We have interactivity. We have optimistic states. We have an entire ecosystem of client side libraries and components, et cetera, but we did have to reclaim those benefits of the, I think DHH called it the majestic monolith. I think monolithic DX is what people ultimately want, and I'm very happy to sort of be contributing to delivering that to people. 
+We have interactivity. We have optimistic states. We have an entire ecosystem of client side libraries and components, et cetera, but we did have to reclaim those benefits of the, I think DHH called it the majestic monolith. I think monolithic DX is what people ultimately want, and I'm very happy to sort of be contributing to delivering that to people.
 
-**Andrew:** so you, you mentioned earlier that like the way you guys build for Vercel is you set out with like a product vision, start at zero and see if the platform can support you. 
+**Andrew:** so you, you mentioned earlier that like the way you guys build for Vercel is you set out with like a product vision, start at zero and see if the platform can support you.
 
 
 #### [00:36:45] The Future of Development: Generative UI and AI Integration
 
-**Andrew:** Uh, recently you guys have been experimenting with AI a lot and releasing a lot of like new AI features and libraries. So like, what's your vision for Vercel in the AI category and what do you guys plan to provide developers? 
+**Andrew:** Uh, recently you guys have been experimenting with AI a lot and releasing a lot of like new AI features and libraries. So like, what's your vision for Vercel in the AI category and what do you guys plan to provide developers?
 
 **Guillermo:** Yeah, in two words, our vision is what we call generative UI. We believe that there is a before and after with this LLMs in their ability to generate code on behalf of users. And this LLMs are actually particularly amazing at generating Tailwind, JSX, HTML, those kinds of things. So we created V zero, which you can think of it as a generative UI design tool.
 
@@ -302,13 +302,13 @@ And they just ship AI experiences. So I'm really excited about what generative U
 
 And then there's a long tail of companies that wish they had an app, but getting the Swift developers, the Android developers, the react developers, the Shipping on three platforms is really difficult. But if you can ship a AI experience, because I open pgne. com and I'm like, I don't know why my bill is 300.
 
-Please help me. Or my, my electricity just got cut off. I didn't get a notification. Please help me. So I think there's going to be a very long tail of user interactions. that people are not going to solve with traditional software UI experiences. They're just going to leapfrog to AI. And hopefully this technology can help people get there. 
+Please help me. Or my, my electricity just got cut off. I didn't get a notification. Please help me. So I think there's going to be a very long tail of user interactions. that people are not going to solve with traditional software UI experiences. They're just going to leapfrog to AI. And hopefully this technology can help people get there.
 
-**Andrew:** Currently the SDK, like only streams components you define though. Right. So it's not like a full V zero, like, Oh, I asked it for weather and then it generated a full weather component for me with all the data fetching. 
+**Andrew:** Currently the SDK, like only streams components you define though. Right. So it's not like a full V zero, like, Oh, I asked it for weather and then it generated a full weather component for me with all the data fetching.
 
-Yeah. 
+Yeah.
 
-**Guillermo:** even know you 
+**Guillermo:** even know you
 
 had that. That's kind of by design, by the way, because there's risk with like AI just creating like Imagine that you're Nike and we stream Adidas by mistake, right? So even the brand experience has to be carefully curated, but I do think that's next, right? Like, I believe we can tame these AIs enough That they can create completely novel results.
 
@@ -328,9 +328,9 @@ And you're talking about like companies being able to sort of leapfrog these kin
 
 What do you, like, where do you see this going the next, you know, three to five years, how do you see it projecting? I mean, is it going to be augmenting faster or is it like going to radically change how we interface with things? Like, what is it gonna, what do you
 
-think that future looks like? 
+think that future looks like?
 
-**Guillermo:** I think it's gonna, I think it's going to continue to enhance our productivity at a rate that we haven't really seen with, let's call them like traditional developer tools, right? So, 
+**Guillermo:** I think it's gonna, I think it's going to continue to enhance our productivity at a rate that we haven't really seen with, let's call them like traditional developer tools, right? So,
 
 an example is, if you want to make developers more productive with just Next. js, your options are somewhat limited, right?
 
@@ -366,13 +366,13 @@ When you move from PagesRider to AppRouter, you're translating that. There's mor
 
 Now you use your intelligence to determine, Oh, we're going to use client side rendering and client components over here. We're going to use server components over here. And like, I think the human will be sort of the editor in that process that continues to refine the code that the AI generates.
 
-**Justin:** I totally agree. Like, uh, I, I love to liken my job to being a plumber. Uh, I, I see AI is just a really good wrench. Like we, we invented a really good wrench. That's really going to help a lot of plumbers and help more people become plumbers that weren't them before. 
+**Justin:** I totally agree. Like, uh, I, I love to liken my job to being a plumber. Uh, I, I see AI is just a really good wrench. Like we, we invented a really good wrench. That's really going to help a lot of plumbers and help more people become plumbers that weren't them before.
 
-**Guillermo:** Absolutely. I, I love my job as a plumber 
+**Guillermo:** Absolutely. I, I love my job as a plumber
 
-too. 
+too.
 
-**Justin:** well, let's talk about a different aspect of your job. 
+**Justin:** well, let's talk about a different aspect of your job.
 
 
 #### [00:54:57] Investment Insights: The Power of Obsession and Unreasonable Goals
@@ -381,7 +381,7 @@ too.
 
 **Guillermo:** It's like a meme now. I'm attached to so many memes. There's Vercel memes, there's funding announcement memes.
 
-**Justin:** yeah, for sure. You seem to be, uh, writing a lot of angel checks and I was curious about specifically. Like, what do you look for when you're wanting to invest in a company? 
+**Justin:** yeah, for sure. You seem to be, uh, writing a lot of angel checks and I was curious about specifically. Like, what do you look for when you're wanting to invest in a company?
 
 **Guillermo:** The easy answer is I'm always looking for extraordinarily talented people, um, that have dedicated their life to the pursuit of, uh, success. Sometimes the specific thing that might be overlooked by others. One of my first angel checks was to a company called Auth0 and the founders were unreasonably dedicated to authorization and authentication.
 
@@ -399,11 +399,11 @@ a huge part of the global economy. Classic example here is Shopify starts with u
 
 Turns out there were a lot. Uh, and so that's why it has to be sort of that duality of like seems small because otherwise there's no alpha and everybody's in it. And then grows to be unreasonably big and obvious in retrospect. Bitcoin is actually another great example. When I first bought Bitcoin, I thought of it as my classic angel check.
 
-It's like, oh, I'll just put 20, 000 into this thing. People say it's weird and like nobody would want it, but there is a chance and it seems like a niche that could get pretty big. And I think it's exactly like that sort of investment thesis. 
+It's like, oh, I'll just put 20, 000 into this thing. People say it's weird and like nobody would want it, but there is a chance and it seems like a niche that could get pretty big. And I think it's exactly like that sort of investment thesis.
 
 **Andrew:** Yeah, we just had Danny Grant on from Jam Dev and she asked us, how would you invest 100, 000 into super early stage founders? And she said basically the same thing is that a person that is just wildly obsessed with a problem is a great start. And then you expanded upon it saying it's also an unreasonable goal.
 
-So unreasonable goal paired with like unreasonable drive to solve it. 
+So unreasonable goal paired with like unreasonable drive to solve it.
 
 **Guillermo:** You know, over the, over the last couple, it seems like to be accelerating now, like over the last couple quarters, I've been getting a lot of feedback from people that passed on Vercel early on, and they're now coming to me saying why, which I really appreciate. And most of the times it's something along the lines of like, It just seemed so unreasonable.
 
@@ -415,11 +415,11 @@ And crazier than you believe. And you have to be signed up, you have to sign up 
 
 Like I'm going to die before this succeeds. That was my thing. Like I'm going to make this work at all costs. It was kind of my thinking.
 
-**Justin:** That's awesome. 
+**Justin:** That's awesome.
 
 **Andrew:** So, uh, we've covered the, the, your answer, I think, to this question a little bit throughout the episode, but we like to ask it because it's a great way to sum up everything. So what do you think the future of front end looks like? And, uh, what do you think the next wave of apps will be centered around?
 
-What will they look like? 
+What will they look like?
 
 **Guillermo:** Yeah. I think things are going to get a lot easier. We hear a lot of the community feedback about the next JS operator and not only because of AI, but I think it's exciting that AI will fuel this. It's going to get a lot easier to write applications. A glimpse of this future is that kind of joke we made about like, we reinvented PHP, right?
 
@@ -431,16 +431,16 @@ Like you have to develop a mobile app, an iOS app, an Android app, a web app, a 
 
 We kind of talked about why like it was too effortful to create an API route and then create your frontend. What if all you are is frontend? Because all you care about is the customer experience. The interoperability between systems can be automated, everything will be an API in some way, in some senses.
 
-So I think empowering the future with ai, empowering developers with ai, and also helping companies become AI companies, especially when they're struggling to deliver in today's software challenging challenges in in, in the world of today. It's part of our mission now, and, um, we're excited to deliver on it. 
+So I think empowering the future with ai, empowering developers with ai, and also helping companies become AI companies, especially when they're struggling to deliver in today's software challenging challenges in in, in the world of today. It's part of our mission now, and, um, we're excited to deliver on it.
 
-**Andrew:** I'm excited to see you accomplish the goal. It's a, it's a big goal you guys got, but it definitely speaks to the unreasonable goals. 
+**Andrew:** I'm excited to see you accomplish the goal. It's a, it's a big goal you guys got, but it definitely speaks to the unreasonable goals.
 
-**Guillermo:** We we'll get 
+**Guillermo:** We we'll get
 
-there. 
+there.
 
 **Andrew:** So, uh, that's it. All we have for questions. Thanks for coming on. This was a great episode. Me and Justin have been waiting for this one for a while and it was an amazing chance to get to talk to you.
 
-**Guillermo:** Thank you so much. I really had fun with it. 
+**Guillermo:** Thank you so much. I really had fun with it.
 
-**Justin:** Yeah. Thanks so much, Guillermo. Uh, you're, I mean, we're big fans of the work that Verso has done and continues to do. So yeah, wish you all the best of luck and excited to see what comes next. 
+**Justin:** Yeah. Thanks so much, Guillermo. Uh, you're, I mean, we're big fans of the work that Verso has done and continues to do. So yeah, wish you all the best of luck and excited to see what comes next.

--- a/pages/episode/91.mdx
+++ b/pages/episode/91.mdx
@@ -3,6 +3,7 @@ title: Guillermo Rauch - Vercel, The Front End Cloud
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Guillermo-Rauch---Vercel--The-Front-End-Cloud-e2hh01i
 youtube: https://www.youtube.com/watch?v=JMHb5KpV1-k
 tags: technology, Vercel, front end, customer experience, developer tools, open source, react, server components, generative UI, AI, apps, software development, web development, cloud, dev tools
+sponsor: [CodeCrafters, Vercel]
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/92.mdx
+++ b/pages/episode/92.mdx
@@ -3,6 +3,7 @@ title: Dan Abramov - Bluesky, Core React Team, RSC, Strict Dom, and the more!
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Dan-Abramov---Bluesky--Core-React-Team--RSC--Strict-Dom--and-the-more-e2hq6ur
 youtube: https://www.youtube.com/watch?v=Ehjw-Cw_OeY
 tags: react, bluesky, core team, RSC, strict dom, server components, react forget, react compiler
+sponsor: CodeCrafters
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/93.mdx
+++ b/pages/episode/93.mdx
@@ -3,6 +3,7 @@ title: Adam Wathan - Tailwind CSS v4, The Evolution and Technical Journey
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Adam-Wathan---Tailwind-CSS-v4--The-Evolution-and-Technical-Journey-e2i3hu1
 youtube: https://www.youtube.com/watch?v=jOWUnYwBNsA
 tags: technology, css, tailwindcss, web development, design, frontend, dev tools, podcast, adam wathan
+sponsor: CodeCrafters
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/94.mdx
+++ b/pages/episode/94.mdx
@@ -3,6 +3,7 @@ title: Mitchell Hashimoto - Founder of HashiCorp, Author of Terraform, and Thoug
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Mitchell-Hashimoto---Founder-of-HashiCorp--Author-of-Terraform--and-Thoughts-of-Open-Source-Monetization-e2id27t
 youtube: https://www.youtube.com/watch?v=vw61iI08iro
 tags: cloud infrastructure, open source, terraform, hashicorp, monetization, founder, author, pilot, terminal emulator, licensing, sustainability
+sponsor: CodeCrafters
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/95.mdx
+++ b/pages/episode/95.mdx
@@ -3,6 +3,7 @@ title: Johannes Schickling - Prisma, Effect and the rise of Local First Developm
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Johannes-Schickling---Prisma--Effect-and-the-rise-of-Local-First-Development-e2imkfd
 youtube: https://www.youtube.com/watch?v=DvLq8GguZ9Q
 tags: technology, local first, prisma, effect, react, typescript, javascript, performance, tooling, productivity, dev tools, podcast
+sponsor: CodeCrafters
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/97.mdx
+++ b/pages/episode/97.mdx
@@ -3,6 +3,7 @@ title: Scott Chacon - GitHub, GitButler and changing the face of version control
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Scott-Chacon---GitHub--GitButler-and-changing-the-face-of-version-control-e2j8tlt
 youtube: https://www.youtube.com/watch?v=I-D6zChu3YI
 tags: technology, git, github, gitbutler, version control, rust, javascript, ai, developer tools, podcast, software development, programming
+sponsor: Clerk
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/98.mdx
+++ b/pages/episode/98.mdx
@@ -3,6 +3,7 @@ title: Ryan Dahl - Node, Deno, and JSR The Modern JavaScript Registry
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Ryan-Dahl---Node--Deno--and-JSR-The-Modern-JavaScript-Registry-e2jisbq
 youtube: https://www.youtube.com/watch?v=pK93x99FrK8
 tags: technology, javascript, node, deno, jsr, registry, typescript, ecosystem, open source, serverless, cloudflare, cloud functions, state management, sub hosting, wintercg
+sponsor: Clerk
 ---
 
 {/* TAB: SHOW NOTES */}

--- a/pages/episode/99.mdx
+++ b/pages/episode/99.mdx
@@ -1,5 +1,6 @@
 ---
 title: José Valim - Elixir, Erlang, Phoenix, Livebook
+sponsor: Clerk
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Jos-Valim---Elixir--Erlang--Phoenix--Livebook-e2jrtql
 youtube: https://www.youtube.com/watch?v=KIrLxaM_ipk
 tags: Elixir, Erlang, Phoenix, Livebook, technology, programming, functional programming, web development, coding, software development

--- a/pages/episode/99.mdx
+++ b/pages/episode/99.mdx
@@ -1,9 +1,9 @@
 ---
 title: José Valim - Elixir, Erlang, Phoenix, Livebook
-sponsor: Clerk
 spotify: https://podcasters.spotify.com/pod/show/devtoolsfm/episodes/Jos-Valim---Elixir--Erlang--Phoenix--Livebook-e2jrtql
 youtube: https://www.youtube.com/watch?v=KIrLxaM_ipk
 tags: Elixir, Erlang, Phoenix, Livebook, technology, programming, functional programming, web development, coding, software development
+sponsor: Clerk
 ---
 
 {/* TAB: SHOW NOTES */}
@@ -63,7 +63,7 @@ Uh, so before we dive in and start talking more about that, would you like to te
 
 #### [00:01:15] The Origins of Elixir
 
-**Andrew:** So before we start talking about Elixir, we have to start talking about another big programming language. Uh, Elixir is based on a thing called the Erlang VM. Uh, to be honest, I'm a front end developer and I have no clue what that is. So what is the Erlang 
+**Andrew:** So before we start talking about Elixir, we have to start talking about another big programming language. Uh, Elixir is based on a thing called the Erlang VM. Uh, to be honest, I'm a front end developer and I have no clue what that is. So what is the Erlang
 
 **José** I will tell a little bit, uh, like how Elixir came to be, because I think that's probably something we'll talk about in a way, and that's going to answer the question. Uh, it can be a really long story. I'll try to, to summarize it, but, but about like 2000, you know, like today multi core is really, it's commonplace everywhere.
 
@@ -83,9 +83,9 @@ you don't do that, right? What you do is that if you have a list or an array and
 
 So what happens if they try to change the same place in memory? Like what happens if both of them try to delete the same thing in the data structure, right? And then things can go wrong, things like you can get a segmentation fault. And so programming languages, and that's where all the complexity comes from.
 
-And programming languages try to solve this in 
+And programming languages try to solve this in
 
-**José:** different ways but If you cannot 
+**José:** different ways but If you cannot
 
 **José** remove the thing, if you cannot change things in memory, a bunch of the problems, they just disappear. They're not there. And that, and that was what I fell in love with at the time. That was the idea. I was like, oh, so concurrency in those programming languages is going to be much easier.
 
@@ -101,21 +101,21 @@ But then there are like a lot of functional programming languages. Okay. Uh, you
 
 Uh, it can mean like the AirLinks and the library, right? And for me, the, the, really the thing about AirLink, because again, if we go back to 2008, 2009,
 
-all programming languages 
+all programming languages
 
 **José** that were,
 
 Coming out, they were talking about concurrency. Closure had like, uh, first class permitted sort concurrency. Go as well, right?
 
-Like Swift, everything. Swift came a bit later, but everything at the time, they were all talking about concurrency. And the beautiful thing about Erlang is that they were talking about concurrency, but Erlang Uh, and Ling, by the way, was created in the eighties. It's 
+Like Swift, everything. Swift came a bit later, but everything at the time, they were all talking about concurrency. And the beautiful thing about Erlang is that they were talking about concurrency, but Erlang Uh, and Ling, by the way, was created in the eighties. It's
 
-**José:** pretty much erlang and, and, 
+**José:** pretty much erlang and, and,
 
 **José** and, and, and me.
 
-We are pretty much about the same 
+We are pretty much about the same
 
-**José:** age. Um, so erlang was also 
+**José:** age. Um, so erlang was also
 
 **José** talking about concurrency, but what happens, for example, imagine that you're writing some software and you want that software to use all the cores in your machine. You're going to use concurrency. That's what we're talking about, right? But if that software.
 
@@ -131,28 +131,28 @@ So Erlang, uh, it's a programming language and a virtual machine created by Eric
 
 It's a bunch of things connected and exchanging data all the time. That's why they solve those things. Because the problems we face today as web developers, they had to solve that three decades ago. Right. So, uh, yeah. And they built it for telecommunication and, um, yeah. And, uh, today we are using it for web.
 
-**Justin** It's a really awesome story. And it, I mean, Erling is pretty amazing that, you know, they had built all of that. Sort of technology way back in the eighties, you know, so ahead of time for what folks were doing at that time. 
+**Justin** It's a really awesome story. And it, I mean, Erling is pretty amazing that, you know, they had built all of that. Sort of technology way back in the eighties, you know, so ahead of time for what folks were doing at that time.
 
 
 #### [00:10:19] Ad
 
-**Andrew:** We'd like to thank our sponsor for this week clerk. Clerk is a company that offers complete user management. Out of the box and we'll help you improve your developer velocity. 
+**Andrew:** We'd like to thank our sponsor for this week clerk. Clerk is a company that offers complete user management. Out of the box and we'll help you improve your developer velocity.
 
-Auth is one of those things that at first it seems like it might be easy You just add an email, you add a password, but it's something that snowballs over time. There's so many different things you might want to implement. You might want multifactor authentication. You might want single sign-on you might want an easier to wait a log-in with magic links. there's just so many different ways you could implement it. That isn't even scratching the surface of all the things you need to do to make your user system good. 
+Auth is one of those things that at first it seems like it might be easy You just add an email, you add a password, but it's something that snowballs over time. There's so many different things you might want to implement. You might want multifactor authentication. You might want single sign-on you might want an easier to wait a log-in with magic links. there's just so many different ways you could implement it. That isn't even scratching the surface of all the things you need to do to make your user system good.
 
-You'll want things like password breach detection. User profiles. The ability to detect bots. So you aren't overpaying and you know, who is actually using your product. 
+You'll want things like password breach detection. User profiles. The ability to detect bots. So you aren't overpaying and you know, who is actually using your product.
 
-Luckily clerk is here with a full user management solution. That'll help get authentication into your app. Very, very quickly.\ 
+Luckily clerk is here with a full user management solution. That'll help get authentication into your app. Very, very quickly.\
 
-one of the cool things about clerk is they come with a bunch of prebuilt UI components. 
+one of the cool things about clerk is they come with a bunch of prebuilt UI components.
 
 So you don't have to worry about many of the details when integrating auth into your app, you don't have to learn their API APIs. For the most part, all you have to do is use their pre-configured components and you'll have things like sign-in. Sign up. User profiles and organizations right out of the box. They have a whole bunch of helpful SDKs.
 
-That'll help you integrate into modern frameworks and into whatever language you choose. They're even coming out with things that make it easier to use the front end components. They have a new project in beta called clerk elements, which is all of the nice authentication bits, but headless just like Radix so you can style them. 
+That'll help you integrate into modern frameworks and into whatever language you choose. They're even coming out with things that make it easier to use the front end components. They have a new project in beta called clerk elements, which is all of the nice authentication bits, but headless just like Radix so you can style them.
 
-However you want to fit right into your app. 
+However you want to fit right into your app.
 
-But one of the best parts about clerk is how lenient their free tier is You get up to 10,000 monthly active users and you'll never pay for a user on their first day. With clerk, you have everything you need to authenticate and manage your users, freeing you to focus on building. If you want to learn more about clerk, head over to clerk.com. 
+But one of the best parts about clerk is how lenient their free tier is You get up to 10,000 monthly active users and you'll never pay for a user on their first day. With clerk, you have everything you need to authenticate and manage your users, freeing you to focus on building. If you want to learn more about clerk, head over to clerk.com.
 
 Are you tired of hearing these ads? Well become a member of one of the various channels that we support And you never have to hear these ads again. And with that, let's get back to it.
 
@@ -161,9 +161,9 @@ Are you tired of hearing these ads? Well become a member of one of the various c
 
 **Justin** Um, could you talk a little bit about like, so there, I mean, the next part of the story is like, you discover Erlang, you're like, Oh, this is great.
 
-There's some things missing or some things that I don't like. I want to do something like slightly different and build on the legacy here. 
+There's some things missing or some things that I don't like. I want to do something like slightly different and build on the legacy here.
 
-**Justin:** but When you discover 
+**Justin:** but When you discover
 
 **Justin** Erlang, you could have just like, Oh, well, there's this program in language Erlang that has all these great properties. I can just use this for all the things that I'm building.
 
@@ -193,15 +193,15 @@ So there are things that we add in Elixir, like being UTF 8 by default. having t
 
 It's a metaprogramming model and it is, uh, a mechanism for like a For polymorphism for interfaces where it can extend data types.
 
-And I just want you to do a parenthesis that like, this is, um, like this is very abstract in the conversation when I'm saying like, Oh, it's metaprogramming. And, uh, it's like polymorphism. I feel like for 
+And I just want you to do a parenthesis that like, this is, um, like this is very abstract in the conversation when I'm saying like, Oh, it's metaprogramming. And, uh, it's like polymorphism. I feel like for
 
-**José:** people who are actually. don't haven't heard about 
+**José:** people who are actually. don't haven't heard about
 
 **José** Elixir, right?
 
-And they want to try it out. The things that are going to make them excited, like, Oh, this feature in Elixir is great, pattern matching is great. Immutable data structures is great. Concurrency is great. Like all those features, they all 
+And they want to try it out. The things that are going to make them excited, like, Oh, this feature in Elixir is great, pattern matching is great. Immutable data structures is great. Concurrency is great. Like all those features, they all
 
-**José:** come from erlang, right? So, 
+**José:** come from erlang, right? So,
 
 **José** uh, Right. So at some point, like people are like, well, when I started talking about elixir, I, I did not go much to airline events and conferences and people ask me why they're like the airline developers.
 
@@ -213,9 +213,9 @@ Nice. Nice. It's still, you know, you're talking about not having a traditional 
 
 **José** yeah, zero experience. I remember when I said, Oh, I want to give it a try. I bought a couple of things online, uh, to try. I also bought like the, the famous like compiler book with the one with the dragon in the cover that people, I believe still do today for like compiler classes and so on. But I would, I, Probably all together, I've read like 30, 40 pages because I would start reading it and then I would have ideas and then I would go to the computer and try them out.
 
-So, uh, so, and that's usually how I, I learn 
+So, uh, so, and that's usually how I, I learn
 
-**José:** stuff. I am a Impatient learner, 
+**José:** stuff. I am a Impatient learner,
 
 **José** uh, like very, very impatient, very, you know, uh, disorderly or something like that. You know, like just going, trying to get as much information as possible and somehow try to, to deal with that. And, and yeah, and, and I, but I also have to say that.
 
@@ -229,13 +229,13 @@ creating our programming language, which I also, I always found very hard and I 
 
 Like those things they need to compose, they need, you know, you cannot have things like clashing with each other. I feel like in a way it's kind of like a, of a, it's like a Jenga game, right? Like if you take one piece, actually, you know, the thing can fall apart. So, um, So there are a lot of decisions, really many decisions, uh, in there.
 
-And again, 
+And again,
 
-**José:** because the erlang virtual machine 
+**José:** because the erlang virtual machine
 
-**José** is opinionated, there were a bunch of things that I would look at them and I was like, Oh, this is awesome. But like, there's no way I can implement these 
+**José** is opinionated, there were a bunch of things that I would look at them and I was like, Oh, this is awesome. But like, there's no way I can implement these
 
-**José:** efficiently in the erlang virtual machine, 
+**José:** efficiently in the erlang virtual machine,
 
 **José** or it doesn't make sense. So I could. rule it out and not worry about exploring that particular path or design decision.
 
@@ -304,7 +304,7 @@ You don't have to do anything else. You just install the library.
 
 Layers on top of that. Um, maybe we should just jump in and talk about Phoenix next. I do, I have some other questions about the Elixir language itself, and maybe we can like drop those down, especially like some of the improvements that you are making to Elixir right now
 
-**José** Yeah. And, and the, and the question was like, what Elixir is good for, and I talked only about one thing, so we should definitely come back to it, 
+**José** Yeah. And, and the, and the question was like, what Elixir is good for, and I talked only about one thing, so we should definitely come back to it,
 
 
 #### [00:33:34] Phoenix
@@ -382,7 +382,7 @@ And today we are reaping the benefits of that. So we started, so we have like, u
 
 They're not one to one translations. That's something that, because remember, like, at the very beginning, I said, like, when I wanted to, when I started using Erlang, my first idea was to bring objects, So I was kind of doing a one to one translation. So whenever we, like I'm, I'm working with somebody on bringing Elixir to a new domain, I'm always like very aware of that.
 
-Like, let's not do a one to one translation, right? Let's really think about how we can bring these idea or those tools in a way that leverage. 
+Like, let's not do a one to one translation, right? Let's really think about how we can bring these idea or those tools in a way that leverage.
 
 
 #### [00:45:10] Livebook
@@ -460,7 +460,7 @@ Like a lot of people were making scripting languages that were like dynamically 
 
 And then we had things like TypeScript coming out. Uh, we had like a lot of other like focus on strongly type languages. So. Uh, I, I know that there's an ongoing project to think about, like, what types look like in Elixir. And then there's also this other language called Gleam, uh, which also builds on the Erlang, uh, VM, which is a, um, a strongly typed language.
 
-So could you talk a little bit about, about how you're thinking about. Types in the elixir ecosystem and maybe what your plans are there. 
+So could you talk a little bit about, about how you're thinking about. Types in the elixir ecosystem and maybe what your plans are there.
 
 **José** yeah, this is, so how I'm going to get started in here. So today I was thinking about doing a, uh, a tweet, which was pretty much going to be something like I have, I still have to order my thoughts because I, I partially feel that everybody who is like, Super excited about types are wrong and everybody who is like, you know, so not excited at all about types.
 
@@ -570,4 +570,4 @@ I was just to say that I wanted to retire at 40, but, uh, I don't think that's h
 
 So thanks. Thanks Jose for coming on.
 
-**José** Thank you. 
+**José** Thank you.

--- a/utils/processMdx.ts
+++ b/utils/processMdx.ts
@@ -196,6 +196,7 @@ interface FrontMatter {
   youtube: string;
   spotify: string;
   date?: string;
+  sponsor?: string | string[];
 }
 
 export async function processMdx(


### PR DESCRIPTION
## Summary
• Add optional sponsor field to episode frontmatter supporting both single and multiple sponsors
• Update EpisodeRow component to display sponsor information on episode cards in purple
• Add sponsor fields to 84 episodes based on sponsor mentions found in show notes
• Support YAML array syntax for episodes with multiple sponsors

## Changes
- **utils/processMdx.ts**: Updated FrontMatter interface to support `sponsor?: string | string[]`
- **components/EpisodeRow.tsx**: Added sponsor display logic with proper handling for arrays
- **episode files**: Added sponsor fields based on show notes

## Sponsors Added
- **Raycast**: 20 episodes (63-83)
- **CodeCrafters**: 12 episodes (84-95, some with co-sponsors)
- **Clerk**: 9 episodes (97-106) 
- **MUX**: 15 episodes (108-125)
- **WorkOS**: 11 episodes (137-147, some with co-sponsors)
- **RunMe, Mailtrap**: Various co-sponsor episodes

## Test plan
- [x] Build completes successfully without errors
- [x] Episodes page renders correctly
- [x] Single sponsors display properly
- [x] Multiple sponsors display as comma-separated list
- [x] Episodes without sponsors show no sponsor information