### PR TITLE
Fix comma spacing in episode card hosts and guests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ public/rss.xml
 # misc
 .DS_Store
 *.pem
+.conductor
 
 # debug
 npm-debug.log*

--- a/components/EpisodeRow.tsx
+++ b/components/EpisodeRow.tsx
@@ -56,24 +56,22 @@ export const EpisodeRow = (episode: ProcessedMdx) => {
           <div>
             <div className="flex space-x-2 mb-2 text-sm">
               <ColoredText color="gray">Hosts:</ColoredText>
-              <ul className="flex space-x-2 dark:text-gray-400">
+              <ul className="flex space-x-1 dark:text-gray-400">
                 {episode.hosts.map((person, index) => (
-                  <Fragment key={person}>
-                    <li>{person}</li>
-                    {index !== episode.hosts.length - 1 ? ", " : ""}
-                  </Fragment>
+                  <li key={person}>
+                    {person}{index !== episode.hosts.length - 1 ? ", " : ""}
+                  </li>
                 ))}
               </ul>
             </div>
             {episode.guests.length > 0 && (
               <div className="flex space-x-2 mb-2 text-sm">
                 <ColoredText color="gray">Guests:</ColoredText>
-                <ul className="flex space-x-2">
+                <ul className="flex space-x-1">
                   {episode.guests.map((person, index) => (
-                    <Fragment key={person}>
-                      <li>{person}</li>
-                      {index !== episode.guests.length - 1 ? ", " : ""}
-                    </Fragment>
+                    <li key={person}>
+                      {person}{index !== episode.guests.length - 1 ? ", " : ""}
+                    </li>
                   ))}
                 </ul>
               </div>


### PR DESCRIPTION
## Summary
- Fixed comma spacing issue where commas appeared before spaces instead of after in episode card host/guest lists
- Removed unnecessary Fragment wrapper and moved comma inside li element
- Changed from `space-x-2` to `space-x-1` for proper spacing between list items

## Test plan
- [x] Verify episode cards display hosts as "Andrew, Justin" instead of "Andrew ,Justin"
- [x] Check that guest lists also have proper comma spacing
- [x] Ensure spacing looks correct in both light and dark themes