### PR TITLE
Replace special bullets with markdown bullets in episode 142

### DIFF
--- a/pages/episode/142.mdx
+++ b/pages/episode/142.mdx
@@ -11,11 +11,11 @@ sponsor: [WorkOS, Mailtrap]
 In this episode, we talk with James Garbutt about e18e, a community-driven initiative focused on improving the performance of JavaScript packages across the ecosystem.
 
 We discuss:
-	•	The goals and vision behind e18e
-	•	What’s slowing down the JS ecosystem
-	•	Why performance work is often invisible—and how to fix that
-	•	The importance of community coordination in open source
-	•	How developers can get involved in improving the packages they rely on
+- The goals and vision behind e18e
+- What’s slowing down the JS ecosystem
+- Why performance work is often invisible—and how to fix that
+- The importance of community coordination in open source
+- How developers can get involved in improving the packages they rely on
 
 If you care about build times, bundle sizes, and the health of the JavaScript ecosystem, this episode is for you.
 
@@ -24,11 +24,11 @@ Episode sponsored By WorkOS (https://workos.com) and Mailtrap (https://l.rw.rw/d
 {/* LINKS */}
 
 🔗 Links
-	•	e18e Website: https://e18e.dev/
-	•	GitHub: https://github.com/e18e
-	•	Discord: https://discord.gg/e18e
-	•	James on Twitter: https://twitter.com/jgarbutt
-	•	Full episode + transcript: [link to your site if available]
+- e18e Website: https://e18e.dev/
+- GitHub: https://github.com/e18e
+- Discord: https://discord.gg/e18e
+- James on Twitter: https://twitter.com/jgarbutt
+- Full episode + transcript: [link to your site if available]
 
 🎧 Subscribe to Devtools.fm for more conversations with the people behind the tools developers use every day.
 
@@ -52,7 +52,7 @@ Episode sponsored By WorkOS (https://workos.com) and Mailtrap (https://l.rw.rw/d
 
 ## [00:00:21] Introduction
 
-**ANDREW:** Hello, welcome to Devtools.fm. This is a podcast about developer tools and the people who make 'em. I'm Andrew, and this is my co-host Justin.
+**Andrew:** Hello, welcome to Devtools.fm. This is a podcast about developer tools and the people who make 'em. I'm Andrew, and this is my co-host Justin.
 
 **Justin:** Hey everyone. We're really excited to have James Garbutt on with us. So James, you are one of the minds behind this movement called e18e, which is a. Like an initiative to clean up and speed up and just improve the JS ecosystem. So we're really excited to chat about that today. But before we get started, would you like to tell our listeners a little bit more about yourself?
 
@@ -63,7 +63,7 @@ But I've tried, and I'm hopping between all these things. Ee18e is definitely my
 
 ## [00:01:40] What is e18e?
 
-**ANDREW:** Yeah, it's quite a big, lofty initiative and kind, amorphous. can you explain to us what e18e is and where it started?
+**Andrew:** Yeah, it's quite a big, lofty initiative and kind, amorphous. can you explain to us what e18e is and where it started?
 
 **James:** Yeah. some time ago, I think maybe like a year and a half ago or something, there was basically a social thread somewhere. where Bjorn, who was working on Astro at the time and Anthony working on, vite, and I was chipping away at cleaning up dependencies in a whole bunch of things. all, found each other in a thread of all places and, started chatting about maybe we should have a space to discuss this stuff. And we have people like Marvin doing the speed up the ecosystem blogs as well at the same time. so maybe we should at least create a discord or something, we can, all work together on, performance related open source tasks. and so from that, we created, Discord to at least discuss this stuff, which then turned into the EE project where. We can, get more people involved and create issues and, easier to pick up work for everyone else, basically to, just to expose the performance problems more, I imagine. but yeah, it, all came out of just various people trying to improve performance in all sorts of different projects and not knowing about each other's work basically. So it's been really good to connect those people, and just provide a space for, new contributors to get involved as well.
 
@@ -79,7 +79,7 @@ the common use case doesn't need to support node one, for example.
 
 so as long as we have alternatives, we can massively reduce the, dependency tree depth essentially. and if you really do need that stuff, you can still pull in, the, one that supports, old versions. but yeah, the, the drama did help, drive a lot of the effort. We were already working on a lot of this stuff for a long time before then.
 
-**ANDREW:** When people think performance, I don't think they typically think like dependencies in my graph. I think they'd usually think like actual, like runtime performance. So like why was, this tree problem seemingly the first thing you guys went after? And what real world like benefits does reducing the tree like that have.
+**Andrew:** When people think performance, I don't think they typically think like dependencies in my graph. I think they'd usually think like actual, like runtime performance. So like why was, this tree problem seemingly the first thing you guys went after? And what real world like benefits does reducing the tree like that have.
 
 **James:** Yeah, so it is, it's different for each project, obviously, 'cause we're trying to improve, runtime performance, but also, the developer experience performance from App point of view. So the install sort of size, for example, affects, developer tooling more than it affects runtime because you would bundle things so you will tree shake and everything anyway. and similar, if you have a deep dependency tree, it adds complexity for the DX side of things, but doesn't necessarily affect runtime a massive amount. then have ones that are in the middle where, they're, increasingly deep, but also have, a lot of older code in there that could be modernized because the platform's moved on since. so if we can improve those, or create alternatives that lean on more modern primitives and things like that, built in functions and stuff. then, you're gonna improve the runtime performance and the dxin a lot of cases. and, some of these will also be like if you improve bundlers or tools, the output code, that's gonna happen at runtime. But yeah, we still obviously have a lot of, cleanup happening where it just affects dx. that's still important because, you could be pulling down maybe Hundreds of megabytes of install size, when actually you only pull in maybe a few megabytes worth of it in, reality or something like that. so it does still matter quite a lot.
 
@@ -90,7 +90,7 @@ so as long as we have alternatives, we can massively reduce the, dependency tree
 
 **James:** Yeah, so at the minute there's it's one of the tasks that we're trying to work on quite a lot recently because. There's a big list of tools. Basically we have a page on the e and e website called resources, basically links a bunch of these tools. But, these days, like the most common, two that we would use, the node modules spec to which, Anthony, and the, npm graph website, which, visualizes the dependency tree. there's also things like package size dev, which tells you how big themes to all sizes and like bundle phobia, like tools to tell you what the runtime size would be and things like that. but yeah, the minute there's quite a lot of tools and not much connecting it. So we do have some work going on to create like a, unified CLI in library, which joins all these together. 'cause you should be able to run this against your own project, and just get some summary or report or whatever, that tells you if there's warnings from any of these. but yeah, admittedly it is a bit difficult to me. You just have to know like the big list of tools to go to. unfortunately that is documented, but it could be better, obviously if it just works from one place. But yeah, check out the resources page 'cause that is super useful. And we have like link plugins and things like that as well, which help. and like upcoming tooling, things to do with, build plugins and, bundle analyzers and things like that.
 
-**ANDREW:** Yeah, it's cool to see you guys working on the bundle analyzer stuff. that's that's an area that I think is just so under explored and Performance tooling. there's been, there's two web pack ones that have been around for a decade at this point and not changed at all, and nothing has gotten past the, the DX of those.
+**Andrew:** Yeah, it's cool to see you guys working on the bundle analyzer stuff. that's that's an area that I think is just so under explored and Performance tooling. there's been, there's two web pack ones that have been around for a decade at this point and not changed at all, and nothing has gotten past the, the DX of those.
 
 So I'm excited to see if, that area can develop more For sure.
 
@@ -98,7 +98,7 @@ So I'm excited to see if, that area can develop more For sure.
 
 Basically, it checks various things in your package, Jason, like a link to. but all of this is like available, being available in one ui. so you can view the graph, you can view errors with your publish, you can browse through potential well warnings and things. So if we add more features to that. a lot of this should be solved just through using that ui. So if we can have like bundle analysis in there, that would be really good as well. but I think that's the direction we're leaning more into just 'cause like you say, there are already a lot of bundle analyzers, but there's a lot more tools now than there were and, smarter things we can do about, Figuring out duplicates and common JS versus ES modules and all this kind of thing, and even suggesting alternative dependencies and stuff like that. so I'm interested to see where that ends up going. but yeah, we've got a lot of tooling to build.
 
-**ANDREW:** yeah, I'm looking through this and, node modules.dev. once again, Anthony knocks it out of the park. This thing is super cool, for anybody who hasn't been on it. It actually uses a web container, installs the npm module directly into the web container in the browser, and then does lots and lots of.
+**Andrew:** yeah, I'm looking through this and, node modules.dev. once again, Anthony knocks it out of the park. This thing is super cool, for anybody who hasn't been on it. It actually uses a web container, installs the npm module directly into the web container in the browser, and then does lots and lots of.
 
 Checks on like licenses and modules and all that. So this definitely looks like a super cool tool I'd. I'd love to see all the other stuff layered on top of it.
 
@@ -106,7 +106,7 @@ Checks on like licenses and modules and all that. So this definitely looks like 
 
 as with everything that he builds.
 
-**ANDREW:** Yeah, I just popped in one of my packages and oh my, the tree, on that one is quite, large.
+**Andrew:** Yeah, I just popped in one of my packages and oh my, the tree, on that one is quite, large.
 
 **James:** I, I always enjoy just expanding the deepest layer. go to the bottom of the dependency tree and see what's there and you'll find something like, is odd.
 
@@ -141,7 +141,7 @@ And if they do work in some sort of beta version or something, then, we can grad
 
 ## [00:19:58] Node version support in packages
 
-**ANDREW:** One tough topic when it comes to publishing packages is supporting different node versions. part of that, big drama back then was supporting all the way down to some of the oldest node versions and, That's a hard thing to do if you're running a project. it really ups the maintenance burden if you wanna be like, oh, this last version supports all the way back to this old unsupported version.
+**Andrew:** One tough topic when it comes to publishing packages is supporting different node versions. part of that, big drama back then was supporting all the way down to some of the oldest node versions and, That's a hard thing to do if you're running a project. it really ups the maintenance burden if you wanna be like, oh, this last version supports all the way back to this old unsupported version.
 
 So what's your take on supporting node versions like that? And like when we drop an EOL for node 18, how long do you think we should support node 18?
 
@@ -153,7 +153,7 @@ So what's your take on supporting node versions like that? And like when we drop
 
 And, there's an ongoing discussion about source maps as well, but that affects like install size, not runtime performance. So it's, it's fairly low on the priorities, but would make a big difference. Quite a lot of packages, ship source maps and the source maps can often be much bigger than the code itself. so if you didn't ship that, modules would be a lot smaller, but there needs to be some solution to, be able to pull source maps in when you want to debug this stuff. So there's still discussion going on around that. Yeah, in general, if you're maintaining some project or whatever, I would just recommend, around known modules, dev for example, and see what your dependency tree looks like and just be more aware of what you're pulling in. keep an eye out for like duplicate dependencies, for example. different versions of the same thing. you could have a look for a mixture of common js and ES module dependencies and just see if there's more modern alternatives to some packages. smaller ones even. like going back to a tiny Libs example, like Tiny Libs has quite a lot of packages that are more modern and faster and smaller than the older ones they replaced. so yeah, you just browse around, the tiny libs org and unjs as well, both have a lot of, like that. but also you can just run like the, we have a link plugin as well in e18e, you can run that and it'll suggest, replacement, dependencies, basically. It'll detect what you're importing and just, suggest maybe you could use this thing instead. and that's not always another dependency. It could be a built-in thing that browsers have, for example, natively. so yeah, I think a lot of it is just being more aware of your, dependency tree and also just being more aware of how the platform has changed. We ship more features to browsers and node all the time. often people don't realize that something is built in now that they're pulling a package for, you could drop the package and just use the built in function. So definitely keeping an eye on just like change logs and stuff like that, release announcements and things. and then you'll, you'll, end up with a much cleaner code base because of it.
 
-**ANDREW:** Yeah. Hopefully when the require ESM stuff drops, we have to worry about a lot less of this. It's it's hard to anticipate what the new problems will be. It's like we're, very versed in this old problem that we've all struggled with for so long. Like I'm, interested to see if there's An unanticipated thing coming because I know for the longest time we didn't ship require ESM because, the node people are like, oh, it's bad for performance, like having to guess if this file is CJS or ESM.
+**Andrew:** Yeah. Hopefully when the require ESM stuff drops, we have to worry about a lot less of this. It's it's hard to anticipate what the new problems will be. It's like we're, very versed in this old problem that we've all struggled with for so long. Like I'm, interested to see if there's An unanticipated thing coming because I know for the longest time we didn't ship require ESM because, the node people are like, oh, it's bad for performance, like having to guess if this file is CJS or ESM.
 
 So maybe some of those will come to bear their head, but I don't know.
 
@@ -169,11 +169,11 @@ think you will end up with some maintainers that genuinely prefer to use common 
 
 ## [00:30:21] Barrel files and why to avoid them
 
-**ANDREW:** So speaking of bundling and, performance of ESM barrel files are, a big topic when it comes to performance. so why are barrel files so bad for performance and, yeah, Why are they so bad?
+**Andrew:** So speaking of bundling and, performance of ESM barrel files are, a big topic when it comes to performance. so why are barrel files so bad for performance and, yeah, Why are they so bad?
 
 **James:** Terrible. So it's, a good way of seeing this actually is in browsers. let's say you, you have like an ES module that's a barrel file. and, a barrel file by the way, is just some file that re-exports a, bunch of the exports of some of the files. have, having an index file. but let's say you have one in, in a browser especially, and you've just pulled it from Unpackage or something, some CDN, the, from the module resolution then of your browser, it will have to send a request to all those modules that it's re-export even if you don't use them. In a bundle, you can k like, you can get rid of some of that, but it does mess with tree shaking a lot as well. So you are better off just, importing from the exact modules basically what you want. and there are limp plugins to detect this stuff now, and I think Biome has it built in. and, a few other, an ES limp plugin. Because it's just proven to be really bad for tree shaking. but if you run your code natively in browsers, it's even worse obviously, 'cause it has to load those files. so it's, yeah, it's generally just not good for performance, but it is nice for usability sometimes. So that's why we've ended up here. but I think that will change over time because especially with export maps, for example, you can more easily split modules up now and export specific things rather than needing one big index file. we'll see what happens though. 'cause there's, still a lot of them in the wild,
 
-**ANDREW:** Before export maps, it was just, it was so hard to do, like multiple exports without barrel files, right? Like you could throw a js file at the root of your project and then point it at something in a dis folder. But dual packaging hazards abound and, not a fun time. Exports maps have made it better, but the syntax a little, it's a, high bar for most, and it's very, easy to mess up.
+**Andrew:** Before export maps, it was just, it was so hard to do, like multiple exports without barrel files, right? Like you could throw a js file at the root of your project and then point it at something in a dis folder. But dual packaging hazards abound and, not a fun time. Exports maps have made it better, but the syntax a little, it's a, high bar for most, and it's very, easy to mess up.
 
 **James:** Hundred percent. And, that's, I think Ling helps with that. Going back to that, Just something to link the export map basically and help you out because it is a complex thing. A lot of people still get it wrong. simple stuff like putting the types, line after, after the module line itself means that sometimes the types never get loaded, for example. so using a lin, like lint tool or I add types wrong, We'll help you figure that out. But it's, yeah, it is a complex thing in general. and there's import maps as well, but I haven't seen many of those in the wild. so yeah, hopefully there's just good documentation on it.
 
@@ -200,20 +200,20 @@ It's oh, it's slow and it's hard to up. Update that mental model. And it's hard 
 
 Benchmark just to test the, like a new version of Node hasn't come out that makes it slower or something. it would be good to see more libraries doing more of that, I think and, more apps and things.
 
-**ANDREW:** A long time ago, Crockford had wrote, Douglas Crockford, wrote JavaScript, the good parts, talking about oh, like actually only use this like subset of JavaScript. And that was, that was before like ES six and all that stuff. So this has been a while. And as I was reading through the sort of performance recommendations, I was like, I was thinking, do we need another JavaScript, the good parts?
+**Andrew:** A long time ago, Crockford had wrote, Douglas Crockford, wrote JavaScript, the good parts, talking about oh, like actually only use this like subset of JavaScript. And that was, that was before like ES six and all that stuff. So this has been a while. And as I was reading through the sort of performance recommendations, I was like, I was thinking, do we need another JavaScript, the good parts?
 
 **Justin:** should we, as a community, rewrite that book and talk about it in modern terms? And I was curious if there was like one or two things if we like, we're all writing a book like that. What are one or two things that you would like, wanna make sure a hundred percent were added?
 
 **James:** Ooh, that is a tough one. 'cause I'm a big fan of ES modules, for example, but like I explained earlier, I can't really, say, oh, everybody should use ES module. they should, but, if you prefer a different syntax, maybe not. but yeah, there's things like, just different primitives and different built-in functions and stuff you can use now that you couldn't before. using sets and maps and things like that. but also, there's so many proposals out there that are introducing new features that. I, I wish were a thing already so that we could get rid of a lot of older sort of mechanisms and things. I, there was a proposal unfortunately shot down recently that was, adding, polls and records to JavaScript. and it, it would've made a lot of templating engines a lot faster, for example. They would be able to compare, compare two sets of template strings, like between renders basically, a lot easier. yeah, I would, mention like a lot of stuff around these newer primitives. but then at the same time, like it's. The language is changing all the time. People proposals still all the time, and new standards are coming out. so it's very difficult to know what to recommend to people. And friends that don't work in front end and work in, like CA for example, still joke that every day we have a new framework or something. And, every day we've got a new syntax or something. yeah, that's probably a good thing sometimes, just to keep things moving.
 
-**ANDREW:** Yeah, that, that's a double-edged sword. There's lots of movement, but it can be a lot to handle. I don't think I ascribed to that joke as much anymore. sure. Maybe five, eight years ago there were a new framework around every corner, but it's little bit different now. Like I, I take that comment with a, grain of salt.
+**Andrew:** Yeah, that, that's a double-edged sword. There's lots of movement, but it can be a lot to handle. I don't think I ascribed to that joke as much anymore. sure. Maybe five, eight years ago there were a new framework around every corner, but it's little bit different now. Like I, I take that comment with a, grain of salt.
 
 **James:** Yeah, and quite a few of them are, depending on the same stack these days, Everybody uses Vite, for example. Most frameworks and, there's like Pua that runs unjs is working on Nitro, which, has three, this little web server inside it that I think multiple frameworks are gonna be dependent on that soon as well. So it's really good to see that collaboration and that. Even if there is a new framework every day, they're all at least using a lot of the same underlying technology. and actually communicating with each other and collaborating. so it's, not like the old days.
 
 
 ## [00:44:47] Libraries of e18e
 
-**ANDREW:** So in the e18e in the e18e universe, there's three large projects, going around. So there's tiny Libs, unjs and Es tooling. What's like the differences between all of them and how does, does e18e own any of them, or are you just contributors to various things?
+**Andrew:** So in the e18e in the e18e universe, there's three large projects, going around. So there's tiny Libs, unjs and Es tooling. What's like the differences between all of them and how does, does e18e own any of them, or are you just contributors to various things?
 
 **James:** what bas first of all, like one of the early, intents that we had when making e18e was, it shouldn't really own anything. It's just an initiative and a community, to provide a space for people to collaborate. and that's why we have the ES tool in org as well, for example, which holds a bunch of. e18e focused tools, but it isn't e18e and similar, like Tiny Libs existed before e18e, because it, it had tiny bench in at the time, I think, which is really cool. Package for benchmarks. unjs existed before, but they're all basically organizations as in GitHub organizations that, happen to be working on things that are in this space. so es tooling generally holds tools. The e18e community has come up with that, like the link plugin, for example, that help out, suggesting module replacements and things like that. then, js was already being built by pya, who works on like a lot of nooks things. the, That's basically a big collection of packages that are all really focused and well built, and a lot of them are so that you can have an abstraction on top of the various cloud, out there. so you can have, un storage is one of the libraries, which lets you have a storage layer regardless of which cloud you're hosted on. So stuff like, that's really cool. And tiny Libs has like a tiny exec and tiny bench, and Abu a bunch of other packages. and so that's its own org with its own maintainers, that have we, happen to run that one now as well. But, we have our own discord for that, separate from e18e 'cause it existed before that.
 
@@ -228,7 +228,7 @@ It's not a separate thing. You install it will be the new CLI at some point. the
 
 **James:** if you wanna get involved in contributing, for example. We have, e18e issues repo has like loads of open issues, for, a lot of cleanup and speed up stuff, where we've already defined what needs doing, but someone needs to pick the work up. you wanna help out and you want to contribute somewhere, that'll have an impact, on, on a lot of people. It's a really good place to just pick an issue up and try it out. there's loads of people, in the community that will help guide you through that and will do code review and things like that. so like a, an example recently was, a collaboration with 11, where we have an issue, like an umbrella issue in the repo. to just investigate if 11 can be made smaller or faster. a couple of people from the community saw the issue and joined in and started investigating it. and there's maybe been like four, four or five prs landed in 11, and a new release recently that I, think, I think they named it like the e18e release. But, that was really cool to see, that they landed all these prs and it got like 20% smaller or something like that. so yeah, if you wanna get involved on that side of things, just have a look through the issues or join the discord, or both, and there's always people willing to help out and point you in right direction. as a maintainer of your own projects as well. if you maintain open source projects and you want some help, looking into the performance, join the discord and share the project, and people will probably, join in and, contribute. If you're, if you just wanna find out like how to make your project not open source necessarily, but just make your own project faster and lighter. have a read through the, the e18e website use a lot of the, there's a lot of good tools in the resources page. but use the link plugin as well. 'cause that's, that gives you a lot of easy wins in. just suggest alternative dependencies that have already been battle tested and proven out. so in a lot of cases it's a drop in replacement. so you could already have like speed gains and, better memory performance, for example, small memory footprint or install size or whatever, just by replacing a dependency. so I would definitely recommend just running the. And see what it reports, stuff like that basically.
 
-**ANDREW:** that wraps it up for our questions this week. thanks for coming on, James. this has been a particularly inspiring episode to me. I will probably spend my night. Looking at dependency graphs and trying to ship smaller packages, so thanks for coming on and inspiring me and our audience.
+**Andrew:** that wraps it up for our questions this week. thanks for coming on, James. this has been a particularly inspiring episode to me. I will probably spend my night. Looking at dependency graphs and trying to ship smaller packages, so thanks for coming on and inspiring me and our audience.
 
 **James:** Yeah, no worries. Hopefully it, people. Get more interested and involved in performance, changes because for too long it has been low priority, so it would be good to see more people care about this stuff.
 


### PR DESCRIPTION
## Summary
- Replace special bullet characters (•) with standard markdown bullets (-) in episode 142
- Improves consistency with markdown formatting standards

## Test plan
- [x] Verify all bullet points render correctly
- [x] Check that content formatting remains intact
- [x] Ensure no other formatting was affected