### PR TITLE
Fix build: add missing Spotify link to episode 159

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,21 +6,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 devtools.fm is a Next.js 15-based podcast website built with TypeScript and Tailwind CSS 4. The site features episodes stored as MDX files with structured content including show notes, sections, and transcripts.
 
-## Development Commands
+## Getting Started
 
-```bash
-# Development
-pnpm dev                    # Start Next.js dev server (port 3000)
-mise run dev               # Alternative via mise
-
-# Building  
-pnpm build                 # Full build with RSS generation
-pnpm build-rss            # Generate RSS feed only
-
-# Content Management
-pnpm create-new-episode   # Create new episode template in /pages/episode/
-pnpm publish-episode      # Publish episode (see PRODUCTION_PROCESS.md)
-```
+See [README.md](./README.md) for installation instructions, prerequisites, and available development commands.
 
 ## Architecture
 
@@ -56,10 +44,6 @@ Uses Tailwind CSS 4 with new CSS syntax:
 ```
 
 Dark mode is handled via `prefers-color-scheme`. DevTools DS themes (Firefox theme) are integrated for theming.
-
-### Environment Configuration
-
-The project uses mise.toml for environment management with Node.js 22.17.0 and pnpm 10.14.0. The configuration includes path setup for node_modules/.bin and automatic .env loading.
 
 ## Important Context
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 node = "22.17.0"
-pnpm = { version = "10.14.0", postinstall = "node scripts/sync-pnpm-version.js" }
+pnpm = "10.14.0"
 
 [settings]
 experimental = true
@@ -10,7 +10,7 @@ _.path = "node_modules/.bin"
 _.file = ".env"
 
 [hooks]
-postinstall = "pnpm install"
+postinstall = ["pnpm install", "node scripts/sync-pnpm-version.js"]
 
 [tasks.dev]
 run = "next dev"

--- a/pages/episode/159.mdx
+++ b/pages/episode/159.mdx
@@ -1,7 +1,7 @@
 ---
 title: Mike Samuel - Google Calendar, Temper Language, Web Standards
 youtube: https://www.youtube.com/watch?v=PsNo8LZkZEg
-spotify:
+spotify: https://open.spotify.com/episode/2myIOp7fLSlDb1Zb17bFpm?si=XofhbbnQQ9KekDj1486PuQ
 tags: mike samuel, google calendar, temper, programming languages, web standards, tc39, w3c, security engineering, cross-language compilation, transpiler, java, javascript, closure compiler
 ---
 


### PR DESCRIPTION
## Summary
- Add Spotify link to episode 159 (Mike Samuel - Google Calendar, Temper Language)
- Update mise.toml to simplify pnpm configuration and ensure sync-pnpm-version script runs
- Streamline CLAUDE.md documentation to reference README.md for setup instructions

## Test plan
Build succeeds with all 174 episodes and RSS generation completes without errors.