### PR TITLE
Fix episode 161 YouTube link

### DIFF
--- a/pages/episode/161.mdx
+++ b/pages/episode/161.mdx
@@ -1,6 +1,6 @@
 ---
 title: Peter van Hardenberg - Ink and Switch, Automerge
-youtube: https://www.youtube.com/watch?v=BgydLnSwrUg
+youtube: https://www.youtube.com/watch?v=9f2owS3nDHs
 spotify: https://www.youtube.com/watch?v=9f2owS3nDHs
 tags: automerge, ink and switch, pvh, peter van hardenberg, distributed systems, collaborative editing, open source, programming languages, software development, computer science, technology, innovatio
 ---


### PR DESCRIPTION
Fixed the YouTube URL for episode 161 to use the correct video ID (9f2owS3nDHs). This resolves the incorrect preview image display.