### PR TITLE
Fix episode 161 Spotify link

### DIFF
--- a/pages/episode/161.mdx
+++ b/pages/episode/161.mdx
@@ -1,7 +1,7 @@
 ---
 title: Peter van Hardenberg - Ink and Switch, Automerge
 youtube: https://www.youtube.com/watch?v=9f2owS3nDHs
-spotify: https://www.youtube.com/watch?v=9f2owS3nDHs
+spotify: https://open.spotify.com/episode/4J3mHNH7hMyH6V8s5I3hB9?si=4qOtRIMQQ3G2-VzFE0HijQ
 tags: automerge, ink and switch, pvh, peter van hardenberg, distributed systems, collaborative editing, open source, programming languages, software development, computer science, technology, innovatio
 ---
 


### PR DESCRIPTION
The Spotify link for episode 161 was incorrectly set to the YouTube URL instead of the actual Spotify episode link. This fix updates it to the correct Spotify link so the preview works properly.