### PR TITLE
Fix TypeScript build errors blocking CI

### DIFF
--- a/app/episode/[episodeNumber]/page.tsx
+++ b/app/episode/[episodeNumber]/page.tsx
@@ -75,10 +75,6 @@ export default async function Episode({
     frontMatter,
   } = processedMdx;
 
-  const showNotesTab = tabSections.find(
-    (tabSection) => tabSection.type === "SHOW NOTES"
-  ) as ShowNotesTab;
-
   const episodeNumberString = `Episode #${episodeNumber}`;
 
   return (

--- a/scripts/generate-episode-descriptions.ts
+++ b/scripts/generate-episode-descriptions.ts
@@ -169,7 +169,7 @@ async function main() {
     existing = {};
   }
 
-  const pending = [];
+  const pending: Awaited<ReturnType<typeof loadEpisodeContext>>[] = [];
 
   for (const file of files) {
     const episodeNumber = file.replace(".mdx", "");


### PR DESCRIPTION
- Remove unused showNotesTab declaration in episode page that referenced
  the unimported ShowNotesTab type, causing "Cannot find name" error.
- Annotate the pending array in generate-episode-descriptions with the
  loadEpisodeContext return type so push() type-checks (was inferred never[]).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GaLs4w1d7zxpKpbu1gW4L3